### PR TITLE
Add minimal autonomous loop, heartbeat, and run-record observability

### DIFF
--- a/bin/run_minimal_loop_once.sh
+++ b/bin/run_minimal_loop_once.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+LANE=""
+DIGEST_AT="${DIGEST_AT:-$(date -u +%Y%m%dT%H)}"
+PROJECT_ID="${PROJECT_ID:-media_monitor}"
+OPERATOR="${OPERATOR:-autonomous-loop}"
+TRIGGER_TYPE="${TRIGGER_TYPE:-timer}"
+ATTEMPT="${ATTEMPT:-1}"
+DRY_RUN="${DRY_RUN:-0}"
+RUN_RECORD_ALL_LANES="${RUN_RECORD_ALL_LANES:-0}"
+
+usage() {
+  cat <<USAGE
+Usage: $0 --lane {sensing|editorial|enrich}
+
+Optional env:
+  DIGEST_AT=YYYYMMDDTHH
+  DRY_RUN=0|1
+  PROJECT_ID=media_monitor
+  OPERATOR=autonomous-loop
+  TRIGGER_TYPE=timer|manual|batch|replay
+  ATTEMPT=1
+  RUN_RECORD_ALL_LANES=0|1   # default 0 instruments only sensing lane
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lane)
+      LANE="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$LANE" ]]; then
+  echo "Missing --lane" >&2
+  usage
+  exit 2
+fi
+
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+write_lane_status() {
+  local exit_code="$1"
+  local status_file="storage/observability/status/${LANE}_latest.json"
+  local summary_file="storage/observability/status/summary.json"
+  local ended_at
+  ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  python - "$status_file" "$summary_file" "$LANE" "$STARTED_AT" "$ended_at" "$TRIGGER_TYPE" "$ATTEMPT" "$exit_code" <<'PY'
+import json, sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HEALTH_THRESHOLDS_HOURS = {
+    "sensing": {"healthy": 2, "degraded": 6},
+    "editorial": {"healthy": 12, "degraded": 24},
+    "enrich": {"healthy": 12, "degraded": 48},
+}
+
+status_file = Path(sys.argv[1])
+summary_file = Path(sys.argv[2])
+lane = sys.argv[3]
+started_at = sys.argv[4]
+ended_at = sys.argv[5]
+trigger_type = sys.argv[6]
+attempt = int(sys.argv[7])
+exit_code = int(sys.argv[8])
+
+status = "success" if exit_code == 0 else "failed"
+error_code = None if exit_code == 0 else f"exit_{exit_code}"
+
+if status_file.exists():
+    try:
+        prev = json.loads(status_file.read_text(encoding="utf-8"))
+    except Exception:
+        prev = {}
+else:
+    prev = {}
+
+last_success_at = ended_at if status == "success" else prev.get("last_success_at")
+
+threshold = HEALTH_THRESHOLDS_HOURS.get(lane, {"healthy": 6, "degraded": 24})
+if last_success_at:
+    last_success_dt = datetime.fromisoformat(last_success_at.replace("Z", "+00:00")).astimezone(timezone.utc)
+    now_dt = datetime.fromisoformat(ended_at.replace("Z", "+00:00")).astimezone(timezone.utc)
+    age_h = (now_dt - last_success_dt).total_seconds() / 3600
+    if age_h <= threshold["healthy"]:
+        health_state = "healthy"
+    elif age_h <= threshold["degraded"]:
+        health_state = "degraded"
+    else:
+        health_state = "down"
+else:
+    health_state = "down"
+
+payload = {
+    "lane": lane,
+    "updated_at": ended_at,
+    "last_run_id": prev.get("last_run_id"),
+    "last_started_at": started_at,
+    "last_ended_at": ended_at,
+    "last_status": status,
+    "last_error_code": error_code,
+    "last_success_at": last_success_at,
+    "trigger_type": trigger_type,
+    "attempt": attempt,
+    "recent_inputs_count": prev.get("recent_inputs_count"),
+    "recent_outputs_count": prev.get("recent_outputs_count"),
+    "record_path": prev.get("record_path", "storage/observability/run_records.jsonl"),
+    "health_state": health_state,
+}
+status_file.parent.mkdir(parents=True, exist_ok=True)
+status_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+if summary_file.exists():
+    try:
+        summary = json.loads(summary_file.read_text(encoding="utf-8"))
+    except Exception:
+        summary = {}
+else:
+    summary = {}
+summary.setdefault("lanes", {})[lane] = {
+    "runs_24h": summary.get("lanes", {}).get(lane, {}).get("runs_24h", 0),
+    "success_24h": summary.get("lanes", {}).get(lane, {}).get("success_24h", 0),
+    "failed_24h": summary.get("lanes", {}).get(lane, {}).get("failed_24h", 0),
+    "inputs_count_24h": summary.get("lanes", {}).get(lane, {}).get("inputs_count_24h", 0),
+    "outputs_count_24h": summary.get("lanes", {}).get(lane, {}).get("outputs_count_24h", 0),
+    "latest": payload,
+}
+summary["updated_at"] = ended_at
+summary.setdefault("window", "24h")
+summary.setdefault("source", {"run_records_path": "storage/observability/run_records.jsonl", "status_dir": "storage/observability/status"})
+summary_file.parent.mkdir(parents=True, exist_ok=True)
+summary_file.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+PY
+}
+
+on_exit() {
+  local exit_code=$?
+  write_lane_status "$exit_code"
+  exit "$exit_code"
+}
+trap on_exit EXIT
+
+run_cmd() {
+  local stage="$1"; shift
+  local cmd=("$@")
+
+  local use_wrapper="0"
+  if [[ "$LANE" == "sensing" || "$RUN_RECORD_ALL_LANES" == "1" ]]; then
+    use_wrapper="1"
+  fi
+
+  if [[ "$use_wrapper" == "1" && -x "scripts/run_with_run_record.py" ]]; then
+    python scripts/run_with_run_record.py \
+      --project-id "$PROJECT_ID" \
+      --operator "$OPERATOR" \
+      --lane "$LANE" \
+      --stage "$stage" \
+      --trigger-type "$TRIGGER_TYPE" \
+      --attempt "$ATTEMPT" \
+      --telemetry-root "storage/observability" \
+      -- "${cmd[@]}"
+  else
+    "${cmd[@]}"
+  fi
+}
+
+echo "[minimal-loop] lane=${LANE} digest_at=${DIGEST_AT} dry_run=${DRY_RUN}"
+
+case "$LANE" in
+  sensing)
+    run_cmd "s01" make s01 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
+    run_cmd "s02" make s02 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
+    run_cmd "s03" make s03 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
+    run_cmd "export_pr3a" make export-pr3a DIGEST_AT="$DIGEST_AT"
+    ;;
+  editorial)
+    run_cmd "s04" make s04 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
+    run_cmd "s05" make s05 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
+    ;;
+  enrich)
+    run_cmd "scrape_enrich" python scripts/06_scrape_enrich.py
+    ;;
+  *)
+    echo "Unsupported lane: $LANE" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+echo "[minimal-loop] lane=${LANE} completed"

--- a/bin/run_sensing_heartbeat.sh
+++ b/bin/run_sensing_heartbeat.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+INTERVAL_SEC="${INTERVAL_SEC:-3600}"
+MAX_RUNS="${MAX_RUNS:-0}"
+DIGEST_AT_MODE="${DIGEST_AT_MODE:-now}"  # now|fixed
+FIXED_DIGEST_AT="${FIXED_DIGEST_AT:-}"
+
+usage() {
+  cat <<USAGE
+Usage: $0 [--interval-sec N] [--max-runs N] [--digest-at-mode now|fixed] [--fixed-digest-at YYYYMMDDTHH]
+
+Env passthrough to lane runner:
+  DRY_RUN, PROJECT_ID, OPERATOR, TRIGGER_TYPE, ATTEMPT, RUN_RECORD_ALL_LANES
+
+Notes:
+  - MAX_RUNS=0 means run forever.
+  - Writes heartbeat log to storage/observability/heartbeat.log.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval-sec)
+      INTERVAL_SEC="${2:-}"
+      shift 2
+      ;;
+    --max-runs)
+      MAX_RUNS="${2:-}"
+      shift 2
+      ;;
+    --digest-at-mode)
+      DIGEST_AT_MODE="${2:-}"
+      shift 2
+      ;;
+    --fixed-digest-at)
+      FIXED_DIGEST_AT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if ! [[ "$INTERVAL_SEC" =~ ^[0-9]+$ ]] || [[ "$INTERVAL_SEC" -lt 1 ]]; then
+  echo "INTERVAL_SEC must be a positive integer" >&2
+  exit 2
+fi
+if ! [[ "$MAX_RUNS" =~ ^[0-9]+$ ]]; then
+  echo "MAX_RUNS must be a non-negative integer" >&2
+  exit 2
+fi
+if [[ "$DIGEST_AT_MODE" != "now" && "$DIGEST_AT_MODE" != "fixed" ]]; then
+  echo "DIGEST_AT_MODE must be now|fixed" >&2
+  exit 2
+fi
+if [[ "$DIGEST_AT_MODE" == "fixed" && -z "$FIXED_DIGEST_AT" ]]; then
+  echo "--fixed-digest-at is required when --digest-at-mode fixed" >&2
+  exit 2
+fi
+
+mkdir -p storage/observability
+HEARTBEAT_LOG="storage/observability/heartbeat.log"
+LOCKFILE="storage/observability/heartbeat.lock"
+
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+  echo "[heartbeat] another heartbeat process is already running" | tee -a "$HEARTBEAT_LOG"
+  exit 0
+fi
+
+run_count=0
+while true; do
+  run_count=$((run_count + 1))
+  started_epoch="$(date +%s)"
+  started_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  if [[ "$DIGEST_AT_MODE" == "fixed" ]]; then
+    DIGEST_AT="$FIXED_DIGEST_AT"
+  else
+    DIGEST_AT="$(date -u +%Y%m%dT%H)"
+  fi
+
+  echo "[heartbeat] run=${run_count} start=${started_iso} digest_at=${DIGEST_AT}" | tee -a "$HEARTBEAT_LOG"
+
+  set +e
+  DIGEST_AT="$DIGEST_AT" \
+  TRIGGER_TYPE="${TRIGGER_TYPE:-timer}" \
+  OPERATOR="${OPERATOR:-heartbeat}" \
+  ATTEMPT="${ATTEMPT:-1}" \
+  PROJECT_ID="${PROJECT_ID:-media_monitor}" \
+  DRY_RUN="${DRY_RUN:-0}" \
+  RUN_RECORD_ALL_LANES="${RUN_RECORD_ALL_LANES:-0}" \
+  bin/run_minimal_loop_once.sh --lane sensing >> "$HEARTBEAT_LOG" 2>&1
+  rc=$?
+  set -e
+
+  ended_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "[heartbeat] run=${run_count} end=${ended_iso} rc=${rc}" | tee -a "$HEARTBEAT_LOG"
+
+  if [[ "$MAX_RUNS" -gt 0 && "$run_count" -ge "$MAX_RUNS" ]]; then
+    echo "[heartbeat] reached max runs (${MAX_RUNS}), exiting" | tee -a "$HEARTBEAT_LOG"
+    break
+  fi
+
+  ended_epoch="$(date +%s)"
+  elapsed=$((ended_epoch - started_epoch))
+  sleep_for=$((INTERVAL_SEC - elapsed))
+  if [[ "$sleep_for" -lt 1 ]]; then
+    sleep_for=1
+  fi
+  sleep "$sleep_for"
+done

--- a/docs/runbooks/pr5-minimal-autonomous-loop.md
+++ b/docs/runbooks/pr5-minimal-autonomous-loop.md
@@ -1,0 +1,172 @@
+# PR5 execution runbook: minimal autonomous loop (alive-first)
+
+## Objective
+
+Define a **small autonomous loop** that keeps the system alive with low intervention, while isolating fragile lanes.
+
+## Lanes and cadence
+
+### Lane 1 — Sensing (mandatory, heartbeat)
+
+Cadence: every 60 minutes.
+
+Entrypoint:
+
+- `bin/run_minimal_loop_once.sh --lane sensing`
+
+Actions:
+
+1. `make s01`
+2. `make s02`
+3. `make s03`
+4. `make export-pr3a`
+
+Expected outputs:
+
+- Fresh digest inputs/materialization in `data/`
+- Stable contract export surfaces (at least PR3a seams) via `storage/buses/*`
+
+Failure isolation:
+
+- Sensing lane must run independently of editorial/enrich.
+- Editorial failure must not block sensing runs.
+
+### Lane 2 — Editorial batch (optional but recommended)
+
+Cadence: every 6 hours.
+
+Entrypoint:
+
+- `bin/run_minimal_loop_once.sh --lane editorial`
+
+Actions:
+
+1. `make s04`
+2. `make s05`
+
+Expected outputs:
+
+- PF outputs + draft generation attempts
+
+Failure isolation:
+
+- If PromptFlow/runtime connection fails, lane is marked failed but system stays alive through sensing lane.
+
+### Lane 3 — Enrich selective (optional, queue-driven)
+
+Cadence: every 2–6 hours or on-demand.
+
+Entrypoint:
+
+- `bin/run_minimal_loop_once.sh --lane enrich`
+
+Actions:
+
+1. `python scripts/06_scrape_enrich.py`
+
+Expected outputs:
+
+- Enriched scrape records for queued work items
+
+Failure isolation:
+
+- Enrich must never block sensing lane execution.
+
+## Producer-side observability boundary
+
+This loop emits **producer telemetry** to:
+
+- `storage/observability/run_records.jsonl`
+- `storage/observability/manifests/`
+- `storage/observability/logs/`
+- `storage/observability/status/<lane>_latest.json`
+
+By default, run-record instrumentation is enabled only for `sensing` lane (safe-first rollout), including `export_pr3a` inside that lane.
+
+- To instrument all lanes: `RUN_RECORD_ALL_LANES=1`
+
+Lane snapshots now follow a common shape:
+
+- `lane`
+- `updated_at`
+- `last_run_id`
+- `last_started_at`
+- `last_ended_at`
+- `last_status`
+- `last_error_code`
+- `last_success_at`
+- `recent_inputs_count`
+- `recent_outputs_count`
+- `health_state` (`healthy|degraded|down`)
+
+A rolling summary is maintained at `storage/observability/status/summary.json` (24h window).
+
+`storage/indexes/` remains reserved for compacted/indexed outputs managed by a single-writer aggregator.
+
+## Health signals (minimal)
+
+Track these five indicators:
+
+1. Last successful sensing run timestamp.
+2. New `news_ref` outputs in last 24h (or closest export proxy).
+3. Last digest export timestamp.
+4. Last successful editorial batch timestamp.
+5. Enrich backlog trend (queued/running/failed) when DB available.
+
+## Degradation policy
+
+- **Sensing down**: system is not alive; page/alert immediately.
+- **Editorial down only**: system degraded but alive; continue sensing.
+- **Enrich down only**: system degraded but alive; continue sensing + editorial.
+
+## Stop conditions
+
+Pause automation and investigate if:
+
+- No successful sensing run in > 2 cadence windows.
+- Export stage repeatedly succeeds with zero outputs for multiple windows (unexpected dry flow).
+- Error loop repeats with same error code for > N runs.
+
+## Suggested scheduling examples
+
+- Cron/systemd timers should schedule each lane independently.
+- Avoid one monolithic hourly job that runs all heavy stages every tick.
+
+Example cron sketch:
+
+- `0 * * * * bin/run_minimal_loop_once.sh --lane sensing`
+- `15 */6 * * * bin/run_minimal_loop_once.sh --lane editorial`
+- `30 */3 * * * bin/run_minimal_loop_once.sh --lane enrich`
+
+## Notes
+
+- This runbook intentionally optimizes for continuity over perfect completeness.
+- Start with sensing lane reliability; scale editorial/enrich once stable.
+
+
+## Run it now (heartbeat)
+
+If you want lines to start appearing automatically in the next hours:
+
+```bash
+make heartbeat-start INTERVAL_SEC=3600
+```
+
+Check status/log quickly:
+
+```bash
+make heartbeat-status
+```
+
+Stop it:
+
+```bash
+make heartbeat-stop
+```
+
+The heartbeat appends to:
+
+- `storage/observability/heartbeat.log`
+- `storage/observability/run_records.jsonl`
+- `storage/observability/status/sensing_latest.json`
+- `storage/observability/status/summary.json`

--- a/docs/runbooks/pr5-minimal-pr-plan.md
+++ b/docs/runbooks/pr5-minimal-pr-plan.md
@@ -1,0 +1,38 @@
+# PR5 minimal plan (small, low-risk PRs)
+
+## PR-A: clarify ownership and wrapper intent
+
+- Add explicit header notes in wrapper scripts/modules.
+- Add concise map in docs: canonical runtime vs owner source-of-truth vs compatibility wrappers.
+- No behavior change.
+
+## PR-B: archive historical noise safely
+
+- Create `notes/archive/` (and optionally `docs/runbooks/archive/`) for historical-only artifacts.
+- Move low-signal historical notes/evidence snapshots without deleting content.
+- Add index/readme to point to active docs.
+
+## PR-C: add run-record wrapper utility
+
+- Add lightweight command wrapper emitting run record + log + manifest pointer.
+- Keep it optional first; no forced integration into canonical pipeline yet.
+
+## PR-D: wire minimal telemetry pointers
+
+- Adopt wrapper in one safe path first (e.g., export job or non-critical stage wrapper).
+- Verify append behavior and failure capture.
+
+## PR-E: aggregator-facing bootstrap
+
+- Provide sample producer output mapping for downstream single-writer compactor:
+  - projects source rows
+  - runs source JSONL
+  - optional corpus delta inputs
+- Keep compaction/index-writing out of multi-writer runtime paths.
+
+## Done criteria
+
+- Runtime continuity preserved.
+- Clearer ownership taxonomy.
+- At least one reliable run-record emission path available.
+- Clean handoff to external single-writer index compaction.

--- a/docs/runbooks/pr5-observability-indexes-prep.md
+++ b/docs/runbooks/pr5-observability-indexes-prep.md
@@ -1,0 +1,116 @@
+# PR5 design memo: observability-first prep (KB-compatible)
+
+## Goal
+
+Prepare `media_monitor` to emit stable producer-side execution telemetry that can be compacted by a **single writer** into UI-facing indexes, without making UI/indexes the source-of-truth.
+
+## Operating model
+
+- Producers emit run records + pointers (manifest/log).
+- Aggregator compacts producer outputs into canonical UI indexes.
+- UI stays read-only over compact indexes only.
+- Rebuild remains possible from ground truth (bus + run records + manifests).
+
+
+## Producer emission location (explicit boundary)
+
+Producer artifacts should live under `storage/observability/` (not final-looking index paths):
+
+- `storage/observability/run_records.jsonl`
+- `storage/observability/manifests/`
+- `storage/observability/logs/`
+- `storage/observability/status/<lane>_latest.json`
+
+`storage/indexes/` is reserved for compacted/indexed views produced by a dedicated single-writer aggregator.
+
+## Canonical UI-facing index target (v0.1)
+
+- `projects.csv`
+- `runs.jsonl`
+- `corpora_daily.jsonl`
+- `refresh.json`
+
+This repo should **prepare producer-side emissions**, not implement a full UI platform.
+
+## Minimal run telemetry contract for this repo
+
+Each relevant execution should emit a run record with at least:
+
+- `run_id`
+- `project_id`
+- `operator`
+- `started_at`
+- `ended_at`
+- `status`
+- `error_code`
+- `inputs_count`
+- `outputs_count`
+- `manifest_path`
+- `log_path`
+
+## Emission points in media_monitor
+
+Recommended emission points (incremental):
+
+1. Stage-level wrapper execution (`make s01..s05` via wrapper script).
+2. Owner entrypoints in `apps/*/entrypoints/`.
+3. Export jobs (`scripts/export_pr3a_buses.py`) as first-class observable runs.
+
+## Internal-only vs public surfaces
+
+Public/contract candidate outputs:
+
+- versioned buses under `storage/buses/*`
+- compacted indexes (aggregator-managed)
+
+Internal-only outputs (not public contracts):
+
+- `data/pf_out/*`
+- quarantine folders
+- queue internals / work items tables
+- ad-hoc draft intermediates not promoted to a contract
+
+## Corpus deltas stance
+
+Near-term recommendation:
+
+- Support both ingestion modes at aggregator boundary (if needed):
+  1) dedicated `corpus_deltas` stream, or
+  2) deltas embedded in run records.
+- Freeze one canonical mode once producers are stable.
+
+For this repo now: postpone mandatory `corpus_deltas` emission until run records are consistently emitted.
+
+## Refresh marker
+
+Proposed `refresh.json` producer/aggregator fields:
+
+- `refreshed_at` (UTC ISO8601)
+- `sources` (array of producer names/paths)
+- `runs_count`
+- `corpora_rows`
+
+
+## Minimal health semantics (producer-side)
+
+Lane health states are computed from `last_success_at` age with conservative defaults:
+
+- `sensing`: healthy <= 2h, degraded <= 6h, else down
+- `editorial`: healthy <= 12h, degraded <= 24h, else down
+- `enrich`: healthy <= 12h, degraded <= 48h, else down
+
+Producer status snapshots should share one shape across lanes and feed a small rolling summary at
+`storage/observability/status/summary.json` for quick operational checks.
+
+## Guardrails
+
+- No multi-writer append to shared compact indexes.
+- No UI reads over repo trees or raw BUS directories.
+- No conversion of indexes into source-of-truth.
+- No exposure of PF raw output as public bus.
+
+## Minimal implementation path
+
+1. Add small shared wrapper that runs commands and always appends run records in `finally` semantics.
+2. Write per-run manifest/log pointers.
+3. Keep compaction to UI indexes outside producer runtime (single writer).

--- a/docs/runbooks/pr5-pruning-diagnostic-and-phased-plan.md
+++ b/docs/runbooks/pr5-pruning-diagnostic-and-phased-plan.md
@@ -1,0 +1,83 @@
+# PR5 diagnostic: controlled pruning + continuity guardrails
+
+## Scope and objective
+
+This document proposes **tree shaking with operational continuity** for `media_monitor`.
+It does **not** propose a runtime rewrite.
+
+Hard constraints:
+
+- Keep canonical runtime path: `bin/run_hour.sh` + `make s01..s05`.
+- Keep domain ownership in `apps/*/src/*`.
+- Keep compatibility wrappers where still needed (`legacy/`, selected `scripts/`).
+
+## Repository classification (current state)
+
+| Zone | Classification | Why | Action stance |
+|---|---|---|---|
+| `bin/run_hour.sh`, `makefile` | canonical runtime | Current global orchestration entrypoint and stage wiring. | Must keep. |
+| `apps/news_acquire/src/news_acquire` | owner source-of-truth | Acquire implementation moved under owner module. | Must keep. |
+| `apps/news_editorial/src/news_editorial` | owner source-of-truth | Editorial implementation moved under owner module. | Must keep. |
+| `apps/news_enrich/src/news_enrich` | owner source-of-truth | Enrich implementation moved under owner module. | Must keep. |
+| `legacy/*.py` stage modules | compatibility wrapper | Canonical Make targets still call these modules. | Keep; annotate wrapper intent. |
+| `backend/` | transitional/internal modules | Useful for migration history and internal reuse. | Keep; avoid promoting as public seam. |
+| `scripts/export_pr3a_buses.py` | runtime-support utility | Material export seam to buses/indexes. | Keep and harden. |
+| `scripts/04_promptflow_run.py`, `scripts/05_explode_pf_outputs.py`, `scripts/06_scrape_enrich.py` | compatibility/ops wrappers | Useful as aditive entrypoints; overlap with staged path. | Keep with explicit ownership labels. |
+| `flow/` | must keep for continuity | PromptFlow remains active editorial seam. | Must keep; postpone invasive changes. |
+| `contracts/schemas` | must keep for continuity | Contract boundaries for interoperability. | Must keep. |
+| `storage/buses`, `storage/indexes` | must keep for continuity | Target public surfaces. | Keep and populate consistently. |
+| `storage/raw` | internal intermediate artifact | Private module storage. | Keep internal-only. |
+| `notes/` | mixed: historical/dev + live context | Contains useful handoff and diagnostics but also noise accumulation risk. | Phase 1 archive/indexing pass. |
+| `docs/runbooks/` | historical + operational | Runbooks are useful but can become hard to navigate. | Keep; add index + archive older evidence snapshots. |
+| local artifacts (`data/pf_out`, quarantine, local logs, drafts) | internal intermediate artifact | Operational scratch and stage internals. | Keep private; do not treat as public bus. |
+
+## Hot spots of structural noise
+
+1. **Ambiguous wrapper vs owner script intent** across `legacy/`, `backend/`, and `scripts/`.
+2. **Documentation sprawl** between `notes/` and `docs/runbooks/` without simple “current vs historical” marker.
+3. **Operational intermediates** (PF outputs/quarantine/drafts/logs) that are useful locally but should not be consumed as contracts.
+
+## Phased pruning plan
+
+### Phase 1 — safe now (very low risk)
+
+- Add/normalize wrapper headers in `legacy/` and wrapper scripts (“compatibility entrypoint; source-of-truth in apps/*”).
+- Add runbook index file grouping docs as: active runbook / historical evidence / migration record.
+- Move purely historical ad-hoc notes to `notes/archive/` (no deletions).
+- Add explicit “internal-only artifacts” section in storage/readme docs.
+
+### Phase 2 — safe with smoke checks
+
+- Consolidate duplicated helper scripts that wrap the same stage behavior.
+- Normalize operational artifact paths for logs/manifests under `storage/indexes/` (or another explicit internal path).
+- Introduce a lightweight run-record wrapper for command execution (single append target) and validate with stage smoke checks.
+
+Smoke checks:
+
+- `make preflight-runtime`
+- `make s01 DRY_RUN=1`
+- `make s02 DRY_RUN=1`
+- `make s03 DRY_RUN=1`
+
+### Phase 3 — postpone
+
+- PromptFlow runtime/connection rewiring (`open_ai_connection`, keyring backend assumptions).
+- Removing legacy wrappers still referenced by Make/runtime path.
+- Structural collapse of `backend/` until runtime ownership usage is fully verified.
+- Any migration that changes canonical orchestration order.
+
+## Stop rules
+
+Stop and postpone if any of these occur:
+
+- A candidate deletion path is still referenced by `make`, `bin/run_hour.sh`, or cron/systemd wrappers.
+- PromptFlow behavior changes are required to complete the cleanup.
+- A cleanup proposal mixes documentation pruning with runtime behavior changes.
+- A path cannot be classified confidently as wrapper/internal/historical.
+
+## Success criteria for pruning
+
+- Lower ambiguity: each path is clearly tagged as canonical, owner, wrapper, internal, or historical.
+- Lower noise: historical materials are archived but preserved.
+- No runtime breakage on canonical stage path.
+- Better readiness for observability compaction inputs.

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ define _env_prefix
 DIGEST_AT=$(DIGEST_AT) DRY_RUN=$(DRY_RUN) LIMIT=$(LIMIT) SAMPLE=$(SAMPLE) NULL_SINK=$(NULL_SINK)
 endef
 
-.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a
+.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a heartbeat-start heartbeat-stop heartbeat-status
 
 help:      ## Show help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' Makefile | sed 's/:.*## / — /' | sort
@@ -176,3 +176,19 @@ scrape-one:   ## Replay one index_id through scraper: make scrape-one KEY=UI4BXX
 
 requeue-fails: ## Requeue failures in the last 24h: make requeue-fails STAGE=generate
 	@$(PYTHON) scripts/requeue_failed.py --stage $(STAGE) --since 24h
+
+
+heartbeat-start: ## Start sensing heartbeat in background (writes storage/observability/heartbeat.log)
+	@mkdir -p storage/observability
+	@if [ -f storage/observability/heartbeat.pid ] && kill -0 "$$(cat storage/observability/heartbeat.pid)" 2>/dev/null; then 	  echo "heartbeat already running pid=$$(cat storage/observability/heartbeat.pid)"; 	  exit 0; 	fi
+	@nohup env INTERVAL_SEC=$${INTERVAL_SEC:-3600} DRY_RUN=$${DRY_RUN:-0} PROJECT_ID=$${PROJECT_ID:-media_monitor} OPERATOR=$${OPERATOR:-heartbeat} TRIGGER_TYPE=$${TRIGGER_TYPE:-timer} ATTEMPT=$${ATTEMPT:-1} RUN_RECORD_ALL_LANES=$${RUN_RECORD_ALL_LANES:-0} 	  bin/run_sensing_heartbeat.sh > /dev/null 2>&1 & echo $$! > storage/observability/heartbeat.pid
+	@echo "heartbeat started pid=$$(cat storage/observability/heartbeat.pid)"
+
+heartbeat-stop: ## Stop sensing heartbeat background process
+	@if [ ! -f storage/observability/heartbeat.pid ]; then echo "heartbeat pid file missing"; exit 0; fi
+	@pid="$$(cat storage/observability/heartbeat.pid)"; 	 if kill -0 "$$pid" 2>/dev/null; then kill "$$pid" && echo "heartbeat stopped pid=$$pid"; else echo "heartbeat pid not running: $$pid"; fi
+	@rm -f storage/observability/heartbeat.pid
+
+heartbeat-status: ## Show heartbeat process and latest log lines
+	@if [ -f storage/observability/heartbeat.pid ] && kill -0 "$$(cat storage/observability/heartbeat.pid)" 2>/dev/null; then 	  echo "heartbeat running pid=$$(cat storage/observability/heartbeat.pid)"; 	else 	  echo "heartbeat not running"; 	fi
+	@tail -n 20 storage/observability/heartbeat.log 2>/dev/null || true

--- a/notes/handoff-memo-monorepo-news.md
+++ b/notes/handoff-memo-monorepo-news.md
@@ -1,0 +1,67 @@
+# Handoff memo: monorepo News / Media Monitor
+
+Este memo resume el estado actual de `media_monitor` para continuidad operativa sin romper runtime.
+
+## Estado del repositorio
+
+- El repo evolucionó de pipeline legacy a monorepo con tres dominios: `news_acquire`, `news_editorial`, `news_enrich`.
+- La arquitectura objetivo existe (apps, contracts, storage), pero la operación canónica aún corre por `bin/run_hour.sh` + `make s01..s05`.
+- `legacy/` permanece como capa de compatibilidad (wrappers), no como zona primaria de nueva lógica.
+
+## Modelo mental correcto
+
+Trabajar con dos capas en paralelo:
+
+1. **Runtime efectivo actual**: `bin/run_hour.sh`, `make s01..s05`, wrappers legacy, datos operativos en `data/`.
+2. **Arquitectura objetivo**: implementación por dominio en `apps/*/src/*`, contratos en `contracts/schemas/`, exports target en `storage/`.
+
+Evitar asumir “migración 100% completa”. El estado real es una transición gobernada.
+
+## Semáforo por dominio
+
+- **Acquire**: más maduro (amarillo tirando a verde).
+- **Editorial**: estructuralmente correcto pero dependiente de PromptFlow y su conexión local (amarillo).
+- **Enrich**: modularizado, aún con necesidad de endurecimiento operativo (amarillo).
+
+## PromptFlow: riesgo operativo clave
+
+- `flow/` sigue siendo seam editorial real.
+- La conexión `open_ai_connection` debe existir en el runtime local de PromptFlow.
+- Variables de entorno no siempre alcanzan; validar connection store/keyring y runtime Python efectivo.
+- Distinguir fallas de código vs fallas de configuración/runtime de PromptFlow.
+
+## Contratos y buses (postura recomendada)
+
+Priorizar superficies públicas mínimas y estables:
+
+- `news_ref.v1`
+- `news_digest_group.v1`
+- `news_topic_cluster.v1` (con cautela de shape)
+- `article_draft.v1` / `news_draft.v1`
+- `scraped_article.v1`
+
+No promover todavía como bus público:
+
+- `pf_out` crudo
+- colas/work items de ejecución
+- artefactos internos de staging
+
+## Principios de trabajo para siguientes PRs
+
+- No hacer refactors masivos ni reemplazo big-bang.
+- Mantener compatibilidad de wrappers mientras se cierra la migración.
+- Cerrar loops operativos: observabilidad, smoke checks por módulo, taxonomy de fallos, manifests e índices útiles.
+- Usar contratos versionados como frontera entre módulos/sistemas.
+
+## Rutas de inspección rápida
+
+- Runtime: `bin/run_hour.sh`, `makefile`
+- Acquire: `apps/news_acquire/README.md`, `apps/news_acquire/runbook.md`, `apps/news_acquire/src/news_acquire/`
+- Editorial: `apps/news_editorial/README.md`, `apps/news_editorial/runbook.md`, `apps/news_editorial/src/news_editorial/`, `flow/`
+- Enrich: `apps/news_enrich/README.md`, `apps/news_enrich/runbook.md`, `apps/news_enrich/src/news_enrich/`
+- Contratos: `contracts/README.md`, `contracts/schemas/`
+- Storage: `storage/README.md`
+
+## Frase guía
+
+`media_monitor` está en consolidación post-migración: la arquitectura objetivo ya existe y está parcialmente implementada con código real; el trabajo útil ahora es cerrar la brecha entre ownership modular, operación cotidiana, exports estables y observabilidad.

--- a/scripts/run_with_run_record.py
+++ b/scripts/run_with_run_record.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Minimal command wrapper that emits producer-side run telemetry.
+
+This utility writes producer emissions under storage/observability by default.
+It does not implement single-writer compaction for UI-facing indexes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Sequence
+
+HEALTH_THRESHOLDS_HOURS = {
+    "sensing": {"healthy": 2, "degraded": 6},
+    "editorial": {"healthy": 12, "degraded": 24},
+    "enrich": {"healthy": 12, "degraded": 48},
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def utc_now_iso() -> str:
+    return utc_now().replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_iso_utc(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def health_state_for_lane(lane: str, last_success_at: str | None, now_dt: datetime) -> str:
+    last_success_dt = parse_iso_utc(last_success_at)
+    if not last_success_dt:
+        return "down"
+    threshold = HEALTH_THRESHOLDS_HOURS.get(lane, {"healthy": 6, "degraded": 24})
+    age_h = (now_dt - last_success_dt).total_seconds() / 3600
+    if age_h <= threshold["healthy"]:
+        return "healthy"
+    if age_h <= threshold["degraded"]:
+        return "degraded"
+    return "down"
+
+
+def ensure_parent(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def append_jsonl(path: Path, record: dict) -> None:
+    ensure_parent(path)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def write_json(path: Path, payload: dict) -> None:
+    ensure_parent(path)
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+
+
+def git_commit_sha() -> str:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"], capture_output=True, text=True, check=False
+    )
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a command and emit a producer run record.")
+    parser.add_argument("--project-id", required=True)
+    parser.add_argument("--lane", default="unknown")
+    parser.add_argument("--stage", default="unspecified")
+    parser.add_argument("--trigger-type", default="manual")
+    parser.add_argument("--attempt", type=int, default=1)
+    parser.add_argument("--operator", default=os.getenv("USER", "unknown"))
+    parser.add_argument("--inputs-count", type=int)
+    parser.add_argument("--outputs-count", type=int)
+    parser.add_argument("--telemetry-root", default="storage/observability")
+    parser.add_argument("--runs-path")
+    parser.add_argument("--manifests-dir")
+    parser.add_argument("--logs-dir")
+    parser.add_argument("--status-dir")
+    parser.add_argument("--summary-path")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("missing command; pass command after '--'")
+    return args
+
+
+def _to_int_or_none(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def write_summary(runs_path: Path, status_dir: Path, summary_path: Path, now_dt: datetime) -> None:
+    cutoff = now_dt - timedelta(hours=24)
+    per_lane: dict[str, dict[str, object]] = {}
+
+    if runs_path.exists():
+        with runs_path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                lane = rec.get("lane") or "unknown"
+                started = parse_iso_utc(rec.get("started_at"))
+                if not started or started < cutoff:
+                    continue
+
+                lane_acc = per_lane.setdefault(
+                    lane,
+                    {
+                        "runs_24h": 0,
+                        "success_24h": 0,
+                        "failed_24h": 0,
+                        "inputs_count_24h": 0,
+                        "outputs_count_24h": 0,
+                    },
+                )
+                lane_acc["runs_24h"] = int(lane_acc["runs_24h"]) + 1
+                if rec.get("status") == "success":
+                    lane_acc["success_24h"] = int(lane_acc["success_24h"]) + 1
+                else:
+                    lane_acc["failed_24h"] = int(lane_acc["failed_24h"]) + 1
+
+                in_count = _to_int_or_none(rec.get("inputs_count"))
+                out_count = _to_int_or_none(rec.get("outputs_count"))
+                lane_acc["inputs_count_24h"] = int(lane_acc["inputs_count_24h"]) + (in_count or 0)
+                lane_acc["outputs_count_24h"] = int(lane_acc["outputs_count_24h"]) + (out_count or 0)
+
+    lane_status = {}
+    if status_dir.exists():
+        for status_file in sorted(status_dir.glob("*_latest.json")):
+            try:
+                payload = json.loads(status_file.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            lane = payload.get("lane") or status_file.name.replace("_latest.json", "")
+            lane_status[lane] = payload
+
+    summary = {
+        "updated_at": now_dt.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        "window": "24h",
+        "source": {
+            "run_records_path": str(runs_path),
+            "status_dir": str(status_dir),
+        },
+        "lanes": {},
+    }
+
+    for lane in sorted(set(per_lane) | set(lane_status)):
+        summary["lanes"][lane] = {
+            **per_lane.get(
+                lane,
+                {
+                    "runs_24h": 0,
+                    "success_24h": 0,
+                    "failed_24h": 0,
+                    "inputs_count_24h": 0,
+                    "outputs_count_24h": 0,
+                },
+            ),
+            "latest": lane_status.get(lane),
+        }
+
+    write_json(summary_path, summary)
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+
+    telemetry_root = Path(args.telemetry_root)
+    runs_path = Path(args.runs_path) if args.runs_path else telemetry_root / "run_records.jsonl"
+    manifests_dir = Path(args.manifests_dir) if args.manifests_dir else telemetry_root / "manifests"
+    logs_dir = Path(args.logs_dir) if args.logs_dir else telemetry_root / "logs"
+    status_dir = Path(args.status_dir) if args.status_dir else telemetry_root / "status"
+    summary_path = Path(args.summary_path) if args.summary_path else status_dir / "summary.json"
+
+    run_id = str(uuid.uuid4())
+    started_at = utc_now_iso()
+    now_dt = utc_now()
+
+    log_path = logs_dir / f"{run_id}.log"
+    manifest_path = manifests_dir / f"{run_id}.json"
+    status_path = status_dir / f"{args.lane}_latest.json"
+
+    ensure_parent(log_path)
+
+    proc = subprocess.run(args.command, capture_output=True, text=True)
+
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, file=sys.stderr, end="")
+
+    with log_path.open("w", encoding="utf-8") as lf:
+        if proc.stdout:
+            lf.write("[stdout]\n")
+            lf.write(proc.stdout)
+            if not proc.stdout.endswith("\n"):
+                lf.write("\n")
+        if proc.stderr:
+            lf.write("[stderr]\n")
+            lf.write(proc.stderr)
+            if not proc.stderr.endswith("\n"):
+                lf.write("\n")
+
+    status = "success" if proc.returncode == 0 else "failed"
+    error_code = "" if proc.returncode == 0 else f"exit_{proc.returncode}"
+    ended_at = utc_now_iso()
+
+    manifest = {
+        "run_id": run_id,
+        "project_id": args.project_id,
+        "lane": args.lane,
+        "stage": args.stage,
+        "trigger_type": args.trigger_type,
+        "attempt": args.attempt,
+        "command": args.command,
+        "cwd": str(Path.cwd()),
+        "hostname": socket.gethostname(),
+        "git_commit": git_commit_sha(),
+        "status": status,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "log_path": str(log_path),
+    }
+    write_json(manifest_path, manifest)
+
+    run_record = {
+        "run_id": run_id,
+        "project_id": args.project_id,
+        "lane": args.lane,
+        "stage": args.stage,
+        "trigger_type": args.trigger_type,
+        "attempt": args.attempt,
+        "operator": args.operator,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "status": status,
+        "error_code": error_code,
+        "inputs_count": args.inputs_count,
+        "outputs_count": args.outputs_count,
+        "command": args.command,
+        "cwd": str(Path.cwd()),
+        "hostname": socket.gethostname(),
+        "git_commit": git_commit_sha(),
+        "manifest_path": str(manifest_path),
+        "log_path": str(log_path),
+    }
+    append_jsonl(runs_path, run_record)
+
+    previous = {}
+    if status_path.exists():
+        try:
+            previous = json.loads(status_path.read_text(encoding="utf-8"))
+        except Exception:
+            previous = {}
+
+    last_success_at = ended_at if status == "success" else previous.get("last_success_at")
+    health_state = health_state_for_lane(args.lane, last_success_at, now_dt)
+
+    status_payload = {
+        "lane": args.lane,
+        "updated_at": ended_at,
+        "last_run_id": run_id,
+        "last_started_at": started_at,
+        "last_ended_at": ended_at,
+        "last_status": status,
+        "last_error_code": error_code or None,
+        "last_success_at": last_success_at,
+        "trigger_type": args.trigger_type,
+        "attempt": args.attempt,
+        "recent_inputs_count": args.inputs_count,
+        "recent_outputs_count": args.outputs_count,
+        "record_path": str(runs_path),
+        "health_state": health_state,
+    }
+    write_json(status_path, status_payload)
+
+    write_summary(runs_path, status_dir, summary_path, now_dt)
+
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
### Motivation

- Provide a small, low-risk autonomous loop to keep sensing runs alive and isolate fragile editorial/enrich lanes. 
- Emit producer-side telemetry so downstream single-writer compaction can build UI-facing indexes without making indexes the runtime source-of-truth.
- Offer a simple heartbeat runner to schedule periodic sensing runs and surface basic health signals per lane.

### Description

- Add `bin/run_minimal_loop_once.sh` to run lane-specific stages (`sensing`, `editorial`, `enrich`) with optional run-record wrapper invocation and per-lane status updates written to `storage/observability/status/*.json`.
- Add `bin/run_sensing_heartbeat.sh` to run an hourly heartbeat loop that invokes the sensing lane, writes `storage/observability/heartbeat.log`, and supports `INTERVAL_SEC`, `MAX_RUNS`, and fixed digest modes.
- Add `scripts/run_with_run_record.py`, a minimal wrapper that runs a command, captures stdout/stderr, writes a run manifest and log, appends a run record to `storage/observability/run_records.jsonl`, updates per-lane status, and writes a 24h rolling summary.
- Update `makefile` to add `heartbeat-start`, `heartbeat-stop`, and `heartbeat-status` targets and expose the heartbeat helpers in the Make flow.
- Add runbooks, design memos, pruning plan, PR plan, and a handoff memo under `docs/runbooks/` and `notes/` describing operational practices, telemetry contract, and health thresholds.

### Testing

- No automated test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b47b7ed514832dbffe6d0400873c35)