### PR TITLE
Allow 8-10 char index_id in news_ref schema and add 8-char ID test

### DIFF
--- a/contracts/schemas/news_ref.v1.json
+++ b/contracts/schemas/news_ref.v1.json
@@ -8,7 +8,11 @@
   "properties": {
     "schema_name": { "const": "news_ref.v1" },
     "schema_status": { "const": "stable" },
-    "index_id": { "type": "string", "pattern": "^[A-Za-z0-9]{10}$" },
+    "index_id": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9]{8,10}$",
+      "description": "Accepts 8-10 alphanumeric IDs for compatibility with current producer-native format."
+    },
     "source": { "type": "string", "minLength": 1 },
     "link": { "type": "string", "format": "uri" },
     "first_seen": { "type": "string", "format": "date-time" },

--- a/tests/test_export_pr3a_buses.py
+++ b/tests/test_export_pr3a_buses.py
@@ -95,6 +95,71 @@ def test_export_pr3a_generates_non_empty_buses_and_valid_contracts(tmp_path: Pat
     assert not list(dg_validator.iter_errors(dg_rows[0]))
 
 
+def test_export_pr3a_accepts_8_char_index_id_and_validates_schema(tmp_path: Path):
+    data = tmp_path / "data"
+    storage = tmp_path / "storage"
+
+    _write_csv(
+        data / "master_ref.csv",
+        [
+            {
+                "index_id": "15ef8990",
+                "source": "EL PAIS",
+                "link": "https://elpais.com/economia/example-8",
+                "first_seen": "2026-03-13T16:00:00Z",
+                "last_seen": "2026-03-13T16:00:00Z",
+                "topics": '["Economia"]',
+                "meta": '{"ingest": "rss"}',
+            }
+        ],
+    )
+
+    _write_csv(
+        data / "digest_map" / "20260313T16.csv",
+        [
+            {
+                "digest_file": "digest_A_20260313T16.csv",
+                "article_id": "43",
+                "index_id": "15ef8990",
+                "Title": "Mercado se estabiliza",
+                "Source": "EL PAIS",
+                "Link": "https://elpais.com/economia/example-8",
+                "Published": "2026-03-13T16:00:00Z",
+                "window_type": "4h_window",
+                "Topic": "Economia",
+            }
+        ],
+    )
+
+    out = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--digest-at",
+            "20260313T16",
+            "--data-dir",
+            str(data),
+            "--storage-dir",
+            str(storage),
+            "--contracts-dir",
+            str(ROOT / "contracts"),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "status=exported" in out.stdout
+
+    ref_files = sorted((storage / "buses" / "news_ref" / "v1").glob("news_ref_*.jsonl"))
+    assert ref_files
+    ref_rows = [json.loads(x) for x in ref_files[-1].read_text(encoding="utf-8").splitlines() if x.strip()]
+    assert ref_rows
+    assert ref_rows[0]["index_id"] == "15ef8990"
+
+    ref_validator = Draft202012Validator(_schema("news_ref.v1.json"))
+    assert not list(ref_validator.iter_errors(ref_rows[0]))
+
+
 def test_export_pr3a_noop_when_missing_input(tmp_path: Path):
     storage = tmp_path / "storage"
     out = subprocess.run(


### PR DESCRIPTION
### Motivation
- The news reference contract previously required a 10-character `index_id` which prevents accepting current producer-native 8-character IDs; the schema must allow 8–10 alphanumeric IDs for compatibility.
- Add an explicit test to ensure an 8-character `index_id` exports correctly and passes JSON Schema validation.

### Description
- Updated `contracts/schemas/news_ref.v1.json` to make `properties.index_id` accept the regex `^[A-Za-z0-9]{8,10}$` and added a brief `description` documenting compatibility with the producer-native format.
- Added `test_export_pr3a_accepts_8_char_index_id_and_validates_schema` to `tests/test_export_pr3a_buses.py` which writes `master_ref.csv` and `digest_map` entries using an 8-character `index_id`, runs the export script, asserts the export status, checks the exported `news_ref` row contains the expected `index_id`, and validates it against the `news_ref.v1.json` schema.

### Testing
- Ran `pytest -q tests/test_export_pr3a_buses.py` and all tests passed (`3 passed`).
- The new test asserts the exported `news_ref` row contains the 8-character `index_id` and that schema validation via `Draft202012Validator` yields no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4adad44e4832db1445d07ba7eeca1)