### PR TITLE
Add compact PR3a export summary and surface it in sensing status

### DIFF
--- a/bin/run_minimal_loop_once.sh
+++ b/bin/run_minimal_loop_once.sh
@@ -136,6 +136,16 @@ payload = {
     "record_path": prev.get("record_path", "storage/observability/run_records.jsonl"),
     "health_state": health_state,
 }
+for key in (
+    "last_successful_export_at",
+    "last_exported_digest_at",
+    "news_ref_count",
+    "news_digest_group_count",
+    "export_status",
+    "failure_reason",
+):
+    if key in prev:
+        payload[key] = prev.get(key)
 status_file.parent.mkdir(parents=True, exist_ok=True)
 status_file.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 

--- a/scripts/export_pr3a_buses.py
+++ b/scripts/export_pr3a_buses.py
@@ -32,6 +32,14 @@ def _utc_now_compact() -> str:
     return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 
 
+def _compact_to_rfc3339(value: str) -> str:
+    try:
+        dt = datetime.strptime(value, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+        return dt.isoformat().replace("+00:00", "Z")
+    except ValueError:
+        return _to_rfc3339(value)
+
+
 def _read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
@@ -368,6 +376,67 @@ def write_run_record(storage_dir: Path, digest_at: str, export_at: str, results:
     return run_path
 
 
+
+
+def _build_compact_summary(
+    previous: dict[str, Any],
+    digest_at: str,
+    export_at: str,
+    results: list[ExportResult],
+    export_status: str,
+    failure_reason: str | None,
+) -> dict[str, Any]:
+    news_ref = next((r for r in results if r.name == "news_ref.v1"), None)
+    news_digest = next((r for r in results if r.name == "news_digest_group.v1"), None)
+
+    summary = {
+        "last_successful_export_at": previous.get("last_successful_export_at"),
+        "last_exported_digest_at": previous.get("last_exported_digest_at"),
+        "news_ref_count": int(previous.get("news_ref_count") or 0),
+        "news_digest_group_count": int(previous.get("news_digest_group_count") or 0),
+        "export_status": export_status,
+        "failure_reason": failure_reason,
+    }
+
+    if export_status == "success":
+        summary.update(
+            {
+                "last_successful_export_at": _compact_to_rfc3339(export_at),
+                "last_exported_digest_at": digest_at,
+                "news_ref_count": news_ref.count if news_ref else 0,
+                "news_digest_group_count": news_digest.count if news_digest else 0,
+                "failure_reason": None,
+            }
+        )
+    return summary
+
+
+def write_compact_summary(
+    storage_dir: Path,
+    digest_at: str,
+    export_at: str,
+    results: list[ExportResult],
+    export_status: str,
+    failure_reason: str | None,
+) -> Path:
+    idx_dir = storage_dir / "indexes"
+    idx_dir.mkdir(parents=True, exist_ok=True)
+    latest = idx_dir / "pr3a_export_compact_latest.json"
+
+    previous: dict[str, Any] = {}
+    if latest.exists():
+        try:
+            previous = _read_json(latest)
+        except Exception:
+            previous = {}
+
+    payload = _build_compact_summary(previous, digest_at, export_at, results, export_status, failure_reason)
+    _write_json(latest, payload)
+
+    run_file = idx_dir / f"pr3a_export_compact_{digest_at}_{export_at}.json"
+    _write_json(run_file, payload)
+    return latest
+
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="PR3a real exports from legacy outputs to storage buses/indexes")
     p.add_argument("--digest-at", required=True, help="Hour bucket YYYYMMDDTHH")
@@ -385,20 +454,38 @@ def main() -> int:
     storage_dir = Path(args.storage_dir)
     contracts_dir = Path(args.contracts_dir)
 
-    results = [
-        export_news_ref(data_dir, storage_dir, contracts_dir, export_at),
-        export_news_digest_group(data_dir, storage_dir, contracts_dir, digest_at, export_at),
-    ]
+    try:
+        results = [
+            export_news_ref(data_dir, storage_dir, contracts_dir, export_at),
+            export_news_digest_group(data_dir, storage_dir, contracts_dir, digest_at, export_at),
+        ]
 
-    run_record = write_run_record(storage_dir, digest_at, export_at, results)
-    index_record = write_indexes(storage_dir, digest_at, export_at, results)
+        run_record = write_run_record(storage_dir, digest_at, export_at, results)
+        index_record = write_indexes(storage_dir, digest_at, export_at, results)
+        compact_summary = write_compact_summary(
+            storage_dir, digest_at, export_at, results, export_status="success", failure_reason=None
+        )
 
-    print(f"[pr3a-export] digest_at={digest_at} export_at={export_at}")
-    for r in results:
-        print(f"[pr3a-export] {r.name} status={r.status} count={r.count} source={r.source} output={r.output_path}")
-    print(f"[pr3a-export] run_record={run_record}")
-    print(f"[pr3a-export] index_record={index_record}")
-    return 0
+        print(f"[pr3a-export] digest_at={digest_at} export_at={export_at}")
+        for r in results:
+            print(f"[pr3a-export] {r.name} status={r.status} count={r.count} source={r.source} output={r.output_path}")
+        print(f"[pr3a-export] run_record={run_record}")
+        print(f"[pr3a-export] index_record={index_record}")
+        print(f"[pr3a-export] compact_summary={compact_summary}")
+        return 0
+    except Exception as exc:
+        reason = f"{exc.__class__.__name__}: {exc}"
+        compact_summary = write_compact_summary(
+            storage_dir,
+            digest_at,
+            export_at,
+            results=[],
+            export_status="failed",
+            failure_reason=reason,
+        )
+        print(f"[pr3a-export] ERROR export failed: {reason}", flush=True)
+        print(f"[pr3a-export] compact_summary={compact_summary}", flush=True)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/run_with_run_record.py
+++ b/scripts/run_with_run_record.py
@@ -113,6 +113,22 @@ def _to_int_or_none(value: object) -> int | None:
         return None
 
 
+
+
+def _read_json_file(path: Path) -> dict | None:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def load_pr3a_compact_summary(telemetry_root: Path) -> dict | None:
+    storage_root = telemetry_root.parent
+    compact_path = storage_root / "indexes" / "pr3a_export_compact_latest.json"
+    return _read_json_file(compact_path)
+
 def write_summary(runs_path: Path, status_dir: Path, summary_path: Path, now_dt: datetime) -> None:
     cutoff = now_dt - timedelta(hours=24)
     per_lane: dict[str, dict[str, object]] = {}
@@ -301,6 +317,19 @@ def main(argv: Sequence[str]) -> int:
         "record_path": str(runs_path),
         "health_state": health_state,
     }
+
+    if args.stage == "export_pr3a":
+        compact = load_pr3a_compact_summary(telemetry_root)
+        if compact:
+            for key in (
+                "last_successful_export_at",
+                "last_exported_digest_at",
+                "news_ref_count",
+                "news_digest_group_count",
+                "export_status",
+                "failure_reason",
+            ):
+                status_payload[key] = compact.get(key)
     write_json(status_path, status_payload)
 
     write_summary(runs_path, status_dir, summary_path, now_dt)


### PR DESCRIPTION
### Motivation
- Provide a compact, machine-readable export summary for `export_pr3a` with the fields `last_successful_export_at`, `last_exported_digest_at`, `news_ref_count`, `news_digest_group_count`, `export_status`, and `failure_reason` so telemetry/UI can read export health without opening long logs. 
- Ensure that if `export_pr3a` fails the concise `failure_reason` is written and surfaced to the sensing lane status for quick triage.

### Description
- `scripts/export_pr3a_buses.py`: added `_build_compact_summary`, `write_compact_summary` and `_compact_to_rfc3339`, and wrapped `main()` in `try/except` so a compact summary is always written to `storage/indexes/pr3a_export_compact_latest.json` and per-run snapshots `pr3a_export_compact_<digest>_<export>.json`, including a short `failure_reason` on errors. 
- `scripts/run_with_run_record.py`: added helpers `_read_json_file` and `load_pr3a_compact_summary`, and when `--stage export_pr3a` is run the script reads the compact summary and injects the requested fields into the lane status payload saved at `storage/observability/status/<lane>_latest.json`. 
- `bin/run_minimal_loop_once.sh`: adjusted the lane exit-status writer to preserve the export summary fields from the previous status so they are not dropped by the `on_exit` handler. 

### Testing
- Compiled modified Python files with `python3 -m py_compile scripts/export_pr3a_buses.py scripts/run_with_run_record.py` and the compile succeeded. 
- Ran `scripts/export_pr3a_buses.py` (no-op path) with `python3 scripts/export_pr3a_buses.py --digest-at 20250101T00 --data-dir data --storage-dir storage --contracts-dir contracts` and it completed and wrote the compact summary. 
- Ran the wrapper `scripts/run_with_run_record.py` for sensing stage with `-- /bin/true` and verified `storage/observability/status/sensing_latest.json` contains the exported fields. 
- Performed a failure-path smoke test (missing contracts) and confirmed the compact summary is written with a concise `failure_reason` and that `failure_reason` is propagated into the sensing status; the test showed the field visible without opening logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ae01478c832d8b385f93eeefdd7a)