### PR TITLE
Add compact latest-news access indexes for readable outputs

### DIFF
--- a/bin/run_minimal_loop_once.sh
+++ b/bin/run_minimal_loop_once.sh
@@ -211,6 +211,7 @@ case "$LANE" in
     run_cmd "s02" make s02 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
     run_cmd "s03" make s03 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
     run_cmd "export_pr3a" make export-pr3a DIGEST_AT="$DIGEST_AT"
+    run_cmd "build_news_access_indexes" make build-news-access-indexes
     ;;
   editorial)
     run_cmd "s04" make s04 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ define _env_prefix
 DIGEST_AT=$(DIGEST_AT) DRY_RUN=$(DRY_RUN) LIMIT=$(LIMIT) SAMPLE=$(SAMPLE) NULL_SINK=$(NULL_SINK)
 endef
 
-.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a heartbeat-start heartbeat-stop heartbeat-status
+.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a build-news-access-indexes heartbeat-start heartbeat-stop heartbeat-status
 
 help:      ## Show help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' Makefile | sed 's/:.*## / — /' | sort
@@ -141,6 +141,9 @@ s05:       ## Stage 05 — explode PF outputs → drafts + enqueue generate
 
 export-pr3a: ## PR3a real exports: legacy outputs -> storage buses/indexes
 	@$(PYTHON) scripts/export_pr3a_buses.py --digest-at $(DIGEST_AT)
+
+build-news-access-indexes: ## Build compact readable latest-news access indexes from exported seams
+	@$(PYTHON) scripts/build_news_access_indexes.py
 
 # ------------ Pipelines ------------
 prep:      ## 01+02 on fixed hour (safe defaults DRY_RUN=1)

--- a/scripts/build_news_access_indexes.py
+++ b/scripts/build_news_access_indexes.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _iter_jsonl(path: Path):
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            yield json.loads(line)
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _utc_now_compact() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _to_rfc3339(value: Any) -> str:
+    s = str(value or "").strip()
+    if not s:
+        return "1970-01-01T00:00:00Z"
+    if s.endswith("Z"):
+        return s
+    if " " in s and "T" not in s:
+        s = s.replace(" ", "T")
+    if "+00:00" in s:
+        return s.replace("+00:00", "Z")
+    if len(s) == 19 and "T" in s:
+        return s + "Z"
+    return s
+
+
+def _resolve_export_outputs(storage_dir: Path) -> tuple[str, str, str]:
+    latest = storage_dir / "indexes" / "pr3a_exports_latest.json"
+    if not latest.exists():
+        raise FileNotFoundError(f"missing export index: {latest}")
+
+    payload = _read_json(latest)
+    digest_at = str(payload.get("digest_at") or "").strip()
+    results = payload.get("results") or []
+    if not digest_at:
+        raise ValueError("pr3a_exports_latest.json missing digest_at")
+
+    outputs: dict[str, str] = {}
+    for result in results:
+        name = str(result.get("name") or "").strip()
+        status = str(result.get("status") or "").strip()
+        if status not in {"exported", "skipped_duplicate"}:
+            continue
+        out = str(result.get("output_path") or "").strip()
+        if out:
+            outputs[name] = out
+
+    ref_out = outputs.get("news_ref.v1")
+    group_out = outputs.get("news_digest_group.v1")
+    if not ref_out or not group_out:
+        raise ValueError("missing output_path for news_ref.v1 or news_digest_group.v1 in pr3a_exports_latest.json")
+    return digest_at, ref_out, group_out
+
+
+def _title_from_meta(meta: Any) -> str:
+    if not isinstance(meta, dict):
+        return ""
+    for key in ("title", "headline", "article_title"):
+        val = str(meta.get(key) or "").strip()
+        if val:
+            return val
+    return ""
+
+
+def _build_group_index(group_rows: list[dict[str, Any]]) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    by_link: dict[str, dict[str, Any]] = {}
+    groups: list[dict[str, Any]] = []
+
+    for row in group_rows:
+        digest_at = str(row.get("digest_id_hour") or "").strip()
+        window_type = str(row.get("window_type") or "").strip() or "unknown"
+        topic = str(row.get("topic") or "").strip() or "unknown"
+        group_number = int(row.get("group_number") or 0)
+
+        content = row.get("content")
+        if not isinstance(content, list):
+            content = []
+
+        titles: list[str] = []
+        for article in content:
+            if not isinstance(article, dict):
+                continue
+            link = str(article.get("link") or "").strip()
+            title = str(article.get("title") or "").strip()
+            published_at = _to_rfc3339(article.get("published"))
+            source = str(article.get("source") or "").strip()
+
+            if title:
+                titles.append(title)
+            if link and link not in by_link:
+                by_link[link] = {
+                    "digest_at": digest_at,
+                    "title": title,
+                    "published_at": published_at,
+                    "topic": topic,
+                    "source": source,
+                }
+
+        groups.append(
+            {
+                "digest_at": digest_at,
+                "window_type": window_type,
+                "topic": topic,
+                "group_number": group_number,
+                "article_count": len(content),
+                "top_titles": titles[:3],
+            }
+        )
+
+    groups.sort(key=lambda g: (g["digest_at"], g["window_type"], g["topic"], g["group_number"]))
+    return by_link, groups
+
+
+def build_access_indexes(storage_dir: Path) -> tuple[Path, Path, int, int]:
+    digest_at, ref_output, group_output = _resolve_export_outputs(storage_dir)
+    ref_rows = list(_iter_jsonl(Path(ref_output)))
+    group_rows = list(_iter_jsonl(Path(group_output)))
+
+    by_link, groups = _build_group_index(group_rows)
+
+    refs: list[dict[str, Any]] = []
+    for row in ref_rows:
+        link = str(row.get("link") or "").strip()
+        if not link:
+            continue
+        group_match = by_link.get(link, {})
+        topics = row.get("topics") if isinstance(row.get("topics"), list) else []
+        topic = str(group_match.get("topic") or (topics[0] if topics else "")).strip()
+        title = str(group_match.get("title") or _title_from_meta(row.get("meta")) or "(untitled)").strip()
+
+        refs.append(
+            {
+                "digest_at": str(group_match.get("digest_at") or digest_at),
+                "index_id": str(row.get("index_id") or "").strip(),
+                "title": title,
+                "source": str(row.get("source") or group_match.get("source") or "unknown").strip(),
+                "published_at": _to_rfc3339(group_match.get("published_at") or row.get("first_seen")),
+                "topic": topic or "unknown",
+                "link": link,
+            }
+        )
+
+    refs = [r for r in refs if r["index_id"]]
+    refs.sort(key=lambda r: (r["published_at"], r["index_id"]), reverse=True)
+
+    built_at = _utc_now_compact()
+    idx_dir = storage_dir / "indexes"
+    latest_refs = idx_dir / "news_recent_refs_latest.jsonl"
+    latest_groups = idx_dir / "news_recent_groups_latest.jsonl"
+    _write_jsonl(latest_refs, refs)
+    _write_jsonl(latest_groups, groups)
+
+    _write_jsonl(idx_dir / f"news_recent_refs_{digest_at}_{built_at}.jsonl", refs)
+    _write_jsonl(idx_dir / f"news_recent_groups_{digest_at}_{built_at}.jsonl", groups)
+    return latest_refs, latest_groups, len(refs), len(groups)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Build compact, human-readable latest news indexes from exported seams")
+    p.add_argument("--storage-dir", default="storage")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    latest_refs, latest_groups, ref_count, group_count = build_access_indexes(Path(args.storage_dir))
+    print(f"[news-access] refs={ref_count} groups={group_count}")
+    print(f"[news-access] latest_refs={latest_refs}")
+    print(f"[news-access] latest_groups={latest_groups}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_pr3a_buses.py
+++ b/scripts/export_pr3a_buses.py
@@ -577,7 +577,7 @@ def main() -> int:
 
     try:
         results = [
-            export_news_ref(data_dir, storage_dir, contracts_dir, export_at),
+            export_news_ref(data_dir, storage_dir, contracts_dir, digest_at, export_at),
             export_news_digest_group(data_dir, storage_dir, contracts_dir, digest_at, export_at),
         ]
 

--- a/tests/test_build_news_access_indexes.py
+++ b/tests/test_build_news_access_indexes.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build_news_access_indexes.py"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r, ensure_ascii=False) for r in rows) + "\n", encoding="utf-8")
+
+
+def test_build_news_access_indexes_creates_latest_readable_files(tmp_path: Path):
+    storage = tmp_path / "storage"
+    digest_at = "20260313T20"
+    ref_path = storage / "buses" / "news_ref" / "v1" / "news_ref_20260313T200000Z.jsonl"
+    group_path = storage / "buses" / "news_digest_group" / "v1" / "news_digest_group_20260313T20_20260313T200000Z.jsonl"
+
+    _write_jsonl(
+        ref_path,
+        [
+            {
+                "schema_name": "news_ref.v1",
+                "schema_status": "stable",
+                "index_id": "15ef8990d6",
+                "source": "EL PAIS",
+                "link": "https://elpais.com/economia/example",
+                "first_seen": "2026-03-13T15:00:00Z",
+                "last_seen": "2026-03-13T15:00:00Z",
+                "topics": ["Economia"],
+                "meta": {},
+                "digest_file": "digest_A_20260313T20.csv",
+                "article_id": "42",
+                "join_key": "digest_A_20260313T20.csv::42",
+            }
+        ],
+    )
+
+    _write_jsonl(
+        group_path,
+        [
+            {
+                "schema_name": "news_digest_group.v1",
+                "schema_status": "experimental_structured",
+                "digest_group_id": "20260313T20:4h_window:Economia:1",
+                "digest_id_hour": digest_at,
+                "window_type": "4h_window",
+                "topic": "Economia",
+                "group_number": 1,
+                "content": [
+                    {
+                        "article_id": "42",
+                        "title": "Inflación baja",
+                        "source": "EL PAIS",
+                        "link": "https://elpais.com/economia/example",
+                        "published": "2026-03-13T15:00:00Z",
+                    }
+                ],
+            }
+        ],
+    )
+
+    _write_json(
+        storage / "indexes" / "pr3a_exports_latest.json",
+        {
+            "digest_at": digest_at,
+            "export_at": "20260313T200000Z",
+            "status": "exported",
+            "results": [
+                {
+                    "name": "news_ref.v1",
+                    "status": "exported",
+                    "count": 1,
+                    "source": "data/master_ref.csv",
+                    "output_path": str(ref_path),
+                    "manifest_path": str(storage / "buses" / "news_ref" / "v1" / "manifest_20260313T200000Z.json"),
+                    "reason": None,
+                },
+                {
+                    "name": "news_digest_group.v1",
+                    "status": "exported",
+                    "count": 1,
+                    "source": "data/digest_jsonls/20260313T20.jsonl",
+                    "output_path": str(group_path),
+                    "manifest_path": str(storage / "buses" / "news_digest_group" / "v1" / "manifest_20260313T200000Z.json"),
+                    "reason": None,
+                },
+            ],
+        },
+    )
+
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT), "--storage-dir", str(storage)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "refs=1 groups=1" in out.stdout
+
+    refs_latest = storage / "indexes" / "news_recent_refs_latest.jsonl"
+    groups_latest = storage / "indexes" / "news_recent_groups_latest.jsonl"
+    assert refs_latest.exists()
+    assert groups_latest.exists()
+
+    ref_rows = [json.loads(line) for line in refs_latest.read_text(encoding="utf-8").splitlines() if line.strip()]
+    group_rows = [json.loads(line) for line in groups_latest.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+    assert ref_rows == [
+        {
+            "digest_at": "20260313T20",
+            "index_id": "15ef8990d6",
+            "title": "Inflación baja",
+            "source": "EL PAIS",
+            "published_at": "2026-03-13T15:00:00Z",
+            "topic": "Economia",
+            "link": "https://elpais.com/economia/example",
+        }
+    ]
+    assert group_rows == [
+        {
+            "digest_at": "20260313T20",
+            "window_type": "4h_window",
+            "topic": "Economia",
+            "group_number": 1,
+            "article_count": 1,
+            "top_titles": ["Inflación baja"],
+        }
+    ]


### PR DESCRIPTION
### Motivation
- The pipeline already exports `news_ref.v1` and `news_digest_group.v1` but lacks a single human-readable surface to quickly inspect recent news. 
- Operators need a compact, canonical file you can open to see title, source, date, topic, digest_at and link without spelunking manifests or raw folders.

### Description
- Add `scripts/build_news_access_indexes.py` which reads `storage/indexes/pr3a_exports_latest.json` and the exported seam outputs to produce `storage/indexes/news_recent_refs_latest.jsonl` and `storage/indexes/news_recent_groups_latest.jsonl` and run-stamped snapshots. 
- Fix `export_pr3a_buses.py` main call to pass `digest_at` into `export_news_ref(...)` to align with the function signature. 
- Wire the new index builder into unattended runs by adding a `build-news-access-indexes` Make target and invoking it from `bin/run_minimal_loop_once.sh` after the `export-pr3a` step. 
- Add `tests/test_build_news_access_indexes.py` to validate the compact latest files contain the expected fields and values. 

### Testing
- Ran `pytest -q tests/test_export_pr3a_buses.py tests/test_build_news_access_indexes.py` and all tests passed (`4 passed`).
- Ran `python3 scripts/build_news_access_indexes.py --help` to verify the CLI help prints correctly (succeeds).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b272e520832d9bd5624d9a31ebfd)