### PR TITLE
Add v1 contracts and fixtures for news briefs, article drafts, and YouTube scripts

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -14,6 +14,9 @@ Draft-but-concrete contracts for incremental migration.
 - `news_topic_cluster.v1`
 - `news_seed_idea.v1`
 - `news_seed_card.v1`
+- `news_piece_brief.v1`
+- `news_article_draft.v1`
+- `news_yt_script_draft.v1`
 
 ## Provenance rule
 

--- a/contracts/schemas/news_article_draft.v1.json
+++ b/contracts/schemas/news_article_draft.v1.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://media-monitor/contracts/news_article_draft.v1.json",
+  "title": "news_article_draft.v1",
+  "description": "Editorial written draft generated from a brief.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "schema_name": { "const": "news_article_draft.v1" },
+    "schema_status": { "const": "experimental_structured" },
+    "draft_id": { "type": "string", "minLength": 1 },
+    "brief_id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "dek": { "type": "string", "minLength": 1 },
+    "lede": { "type": "string", "minLength": 1 },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "section_id": { "type": "string", "minLength": 1 },
+          "heading": { "type": "string", "minLength": 1 },
+          "summary": { "type": "string", "minLength": 1 }
+        },
+        "required": ["section_id", "heading", "summary"]
+      }
+    },
+    "body_markdown": { "type": "string", "minLength": 1 },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "citation_id": { "type": "string", "minLength": 1 },
+          "claim_text": { "type": "string", "minLength": 1 },
+          "source_ref_id": { "type": "string", "minLength": 1 },
+          "url": { "type": "string", "format": "uri" }
+        },
+        "required": ["citation_id", "claim_text", "source_ref_id", "url"]
+      }
+    },
+    "fact_check_flags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "flag": { "type": "string", "minLength": 1 },
+          "severity": { "type": "string", "enum": ["low", "medium", "high"] },
+          "note": { "type": "string", "minLength": 1 }
+        },
+        "required": ["flag", "severity", "note"]
+      }
+    },
+    "revision_notes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "required": [
+    "schema_name",
+    "schema_status",
+    "draft_id",
+    "brief_id",
+    "title",
+    "dek",
+    "lede",
+    "sections",
+    "body_markdown",
+    "citations",
+    "fact_check_flags",
+    "revision_notes"
+  ]
+}

--- a/contracts/schemas/news_piece_brief.v1.json
+++ b/contracts/schemas/news_piece_brief.v1.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://media-monitor/contracts/news_piece_brief.v1.json",
+  "title": "news_piece_brief.v1",
+  "description": "Editorial brief contract used to guide written and video drafting.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "schema_name": { "const": "news_piece_brief.v1" },
+    "schema_status": { "const": "experimental_structured" },
+    "brief_id": { "type": "string", "minLength": 1 },
+    "seed_id": { "type": "string", "minLength": 1 },
+    "target_format": {
+      "type": "string",
+      "enum": ["article", "youtube_script", "newsletter", "short_video"]
+    },
+    "audience": { "type": "string", "minLength": 1 },
+    "editorial_goal": { "type": "string", "minLength": 1 },
+    "core_claim": { "type": "string", "minLength": 1 },
+    "sections": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "section_id": { "type": "string", "minLength": 1 },
+          "heading": { "type": "string", "minLength": 1 },
+          "purpose": { "type": "string", "minLength": 1 },
+          "key_points": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "required": ["section_id", "heading", "purpose", "key_points"]
+      }
+    },
+    "must_include": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "must_avoid": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "source_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "ref_id": { "type": "string", "minLength": 1 },
+          "title": { "type": "string", "minLength": 1 },
+          "url": { "type": "string", "format": "uri" }
+        },
+        "required": ["ref_id", "title", "url"]
+      }
+    },
+    "tone": { "type": "string", "minLength": 1 },
+    "freshness_window": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "from": { "type": "string", "format": "date-time" },
+        "to": { "type": "string", "format": "date-time" }
+      },
+      "required": ["from", "to"]
+    }
+  },
+  "required": [
+    "schema_name",
+    "schema_status",
+    "brief_id",
+    "seed_id",
+    "target_format",
+    "audience",
+    "editorial_goal",
+    "core_claim",
+    "sections",
+    "must_include",
+    "must_avoid",
+    "source_refs",
+    "tone",
+    "freshness_window"
+  ]
+}

--- a/contracts/schemas/news_yt_script_draft.v1.json
+++ b/contracts/schemas/news_yt_script_draft.v1.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://media-monitor/contracts/news_yt_script_draft.v1.json",
+  "title": "news_yt_script_draft.v1",
+  "description": "YouTube-focused draft script generated from a brief.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "schema_name": { "const": "news_yt_script_draft.v1" },
+    "schema_status": { "const": "experimental_structured" },
+    "script_id": { "type": "string", "minLength": 1 },
+    "brief_id": { "type": "string", "minLength": 1 },
+    "title": { "type": "string", "minLength": 1 },
+    "thumbnail_hook": { "type": "string", "minLength": 1 },
+    "cold_open": { "type": "string", "minLength": 1 },
+    "segment_outline": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "segment_id": { "type": "string", "minLength": 1 },
+          "heading": { "type": "string", "minLength": 1 },
+          "beat": { "type": "string", "minLength": 1 },
+          "estimated_seconds": { "type": "integer", "minimum": 1 }
+        },
+        "required": ["segment_id", "heading", "beat", "estimated_seconds"]
+      }
+    },
+    "full_script": { "type": "string", "minLength": 1 },
+    "voice_notes": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "visual_notes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "segment_id": { "type": "string", "minLength": 1 },
+          "direction": { "type": "string", "minLength": 1 },
+          "asset_refs": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "required": ["segment_id", "direction", "asset_refs"]
+      }
+    },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "source_ref_id": { "type": "string", "minLength": 1 },
+          "url": { "type": "string", "format": "uri" },
+          "usage_note": { "type": "string", "minLength": 1 }
+        },
+        "required": ["source_ref_id", "url", "usage_note"]
+      }
+    }
+  },
+  "required": [
+    "schema_name",
+    "schema_status",
+    "script_id",
+    "brief_id",
+    "title",
+    "thumbnail_hook",
+    "cold_open",
+    "segment_outline",
+    "full_script",
+    "voice_notes",
+    "visual_notes",
+    "citations"
+  ]
+}

--- a/contracts/tests/fixtures/news_article_draft.example.json
+++ b/contracts/tests/fixtures/news_article_draft.example.json
@@ -1,0 +1,41 @@
+{
+  "schema_name": "news_article_draft.v1",
+  "schema_status": "experimental_structured",
+  "draft_id": "draft_article_2026_03_14_01",
+  "brief_id": "brief_2026_03_14_001",
+  "title": "Una alianza regional que redefine la carrera de nube empresarial",
+  "dek": "El acuerdo entre dos gigantes tecnológicos eleva la presión de precios y acelera proyectos en empresas medianas.",
+  "lede": "En menos de una semana, el anuncio pasó de promesa a hoja de ruta comercial en tres mercados clave de LATAM.",
+  "sections": [
+    {
+      "section_id": "sec_1",
+      "heading": "Qué se anunció",
+      "summary": "El acuerdo integra infraestructura, soporte y distribución para clientes corporativos."
+    },
+    {
+      "section_id": "sec_2",
+      "heading": "Qué cambia para las empresas",
+      "summary": "Las empresas medianas verán mejores condiciones de entrada, con riesgos de dependencia tecnológica."
+    }
+  ],
+  "body_markdown": "## Qué se anunció\n\nEl acuerdo presentado el martes...\n\n## Qué cambia para las empresas\n\nPara muchas compañías...",
+  "citations": [
+    {
+      "citation_id": "c1",
+      "claim_text": "El acuerdo cubre tres mercados durante su fase inicial.",
+      "source_ref_id": "ref_01",
+      "url": "https://example.com/official-announcement"
+    }
+  ],
+  "fact_check_flags": [
+    {
+      "flag": "Verificar cifra de crecimiento interanual",
+      "severity": "medium",
+      "note": "El comunicado menciona un rango, no un valor puntual."
+    }
+  ],
+  "revision_notes": [
+    "Reforzar contexto histórico de precios en 2024.",
+    "Añadir segundo punto de vista de analista externo."
+  ]
+}

--- a/contracts/tests/fixtures/news_piece_brief.example.json
+++ b/contracts/tests/fixtures/news_piece_brief.example.json
@@ -1,0 +1,56 @@
+{
+  "schema_name": "news_piece_brief.v1",
+  "schema_status": "experimental_structured",
+  "brief_id": "brief_2026_03_14_001",
+  "seed_id": "seed_card_451",
+  "target_format": "article",
+  "audience": "Profesionales de tecnología y negocios en LATAM",
+  "editorial_goal": "Explicar por qué la alianza cambia la competencia regional de nube.",
+  "core_claim": "La alianza acelera adopción empresarial y presiona precios en el segmento medio.",
+  "sections": [
+    {
+      "section_id": "sec_1",
+      "heading": "Qué pasó",
+      "purpose": "Contextualizar el anuncio y actores.",
+      "key_points": [
+        "Fecha del anuncio",
+        "Empresas involucradas",
+        "Mercados afectados"
+      ]
+    },
+    {
+      "section_id": "sec_2",
+      "heading": "Por qué importa",
+      "purpose": "Conectar impacto para audiencia de negocio.",
+      "key_points": [
+        "Impacto en costos",
+        "Riesgos de implementación"
+      ]
+    }
+  ],
+  "must_include": [
+    "Comparación con el escenario de 2024",
+    "Una cita textual de ejecutivo"
+  ],
+  "must_avoid": [
+    "Especulación sin respaldo",
+    "Tono promocional"
+  ],
+  "source_refs": [
+    {
+      "ref_id": "ref_01",
+      "title": "Comunicado oficial de alianza",
+      "url": "https://example.com/official-announcement"
+    },
+    {
+      "ref_id": "ref_02",
+      "title": "Reporte de mercado trimestral",
+      "url": "https://example.com/market-report"
+    }
+  ],
+  "tone": "Analítico, claro y orientado a decisiones.",
+  "freshness_window": {
+    "from": "2026-03-01T00:00:00Z",
+    "to": "2026-03-14T23:59:59Z"
+  }
+}

--- a/contracts/tests/fixtures/news_yt_script_draft.example.json
+++ b/contracts/tests/fixtures/news_yt_script_draft.example.json
@@ -1,0 +1,47 @@
+{
+  "schema_name": "news_yt_script_draft.v1",
+  "schema_status": "experimental_structured",
+  "script_id": "yt_script_2026_03_14_01",
+  "brief_id": "brief_2026_03_14_001",
+  "title": "La alianza tech que puede bajar tus costos de nube",
+  "thumbnail_hook": "¿Se viene guerra de precios en la nube?",
+  "cold_open": "Hoy te explico en 90 segundos por qué este acuerdo puede cambiar cómo tu empresa compra tecnología.",
+  "segment_outline": [
+    {
+      "segment_id": "seg_1",
+      "heading": "El anuncio en una frase",
+      "beat": "Presentación rápida de actores y movimiento.",
+      "estimated_seconds": 20
+    },
+    {
+      "segment_id": "seg_2",
+      "heading": "Impacto real en empresas",
+      "beat": "Costos, velocidad de implementación y riesgos.",
+      "estimated_seconds": 45
+    }
+  ],
+  "full_script": "[COLD OPEN]\nHoy te explico...\n\n[SEGMENTO 1]\nPrimero, qué se anunció...",
+  "voice_notes": [
+    "Ritmo enérgico al inicio",
+    "Bajar velocidad en cifras clave"
+  ],
+  "visual_notes": [
+    {
+      "segment_id": "seg_1",
+      "direction": "Mostrar titulares y logos con zoom lento.",
+      "asset_refs": ["headline_capture_01", "brand_pack_2026"]
+    },
+    {
+      "segment_id": "seg_2",
+      "direction": "Insertar gráfico comparativo de costos.",
+      "asset_refs": ["cost_chart_q1", "latam_map_overlay"]
+    }
+  ],
+  "citations": [
+    {
+      "source_ref_id": "ref_01",
+      "url": "https://example.com/official-announcement",
+      "usage_note": "Dato de cobertura de mercados iniciales."
+    }
+  ]
+}

--- a/contracts/tests/test_contracts.py
+++ b/contracts/tests/test_contracts.py
@@ -17,6 +17,9 @@ CASES = [
     ("news_topic_cluster.v1.json", "news_topic_cluster.example.json"),
     ("news_seed_idea.v1.json", "news_seed_idea.example.json"),
     ("news_seed_card.v1.json", "news_seed_card.example.json"),
+    ("news_piece_brief.v1.json", "news_piece_brief.example.json"),
+    ("news_article_draft.v1.json", "news_article_draft.example.json"),
+    ("news_yt_script_draft.v1.json", "news_yt_script_draft.example.json"),
 ]
 
 


### PR DESCRIPTION
### Motivation
- Provide formal JSON Schema contracts for editorial planning and generated drafts to enable schema validation for writing and video pipelines.
- Add example fixtures so CI can validate generated outputs against the new contracts automatically.

### Description
- Add `contracts/schemas/news_piece_brief.v1.json` defining the editorial brief with fields like `brief_id`, `seed_id`, `target_format`, `audience`, `editorial_goal`, `core_claim`, `sections`, `must_include`, `must_avoid`, `source_refs`, `tone`, and `freshness_window` plus schema metadata.
- Add `contracts/schemas/news_article_draft.v1.json` defining written draft output fields including `title`, `dek`, `lede`, `sections`, `body_markdown`, `citations`, `fact_check_flags`, and `revision_notes`.
- Add `contracts/schemas/news_yt_script_draft.v1.json` defining YouTube script draft fields like `thumbnail_hook`, `cold_open`, `segment_outline`, `full_script`, `voice_notes`, `visual_notes`, and `citations`.
- Add example fixtures under `contracts/tests/fixtures/` for each new schema and register the new pairs in `contracts/tests/test_contracts.py`, and document the schemas in `contracts/README.md` under "Experimental structured".

### Testing
- Ran `pytest -q contracts/tests/test_contracts.py` which executed the fixture-based schema validations.
- All contract fixture validations passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b596426f50832daed880b49315fb2e)