### PR TITLE
Expand news_seed_idea.v1 with editorial decision fields

### DIFF
--- a/apps/news_editorial/README.md
+++ b/apps/news_editorial/README.md
@@ -19,7 +19,7 @@ This PR is additive: it clarifies ownership and operator entrypoints while prese
 
 ### Buses intended to be written by editorial adapters
 - `news_topic_cluster.v1`
-- `news_seed_idea.v1`
+- `news_seed_idea.v1` (expandido de forma backward-compatible con campos editoriales: `format_candidates`, `working_title`, `angle`, `why_now`, `supporting_refs`, `risk_notes`)
 - `news_seed_card.v1`
 
 (These remain planned adapter outputs; this PR does not change contract shapes nor replace runtime.)
@@ -48,6 +48,18 @@ apps/news_editorial/entrypoints/run_editorial_owner.sh
 Wrapper delegates to canonical runtime targets:
 1. `make s04`
 2. `make s05`
+
+
+## Contrato editorial actualizado (`news_seed_idea.v1`)
+- Se mantiene **la misma versión `v1`** para preservar compatibilidad con productores/consumidores actuales.
+- Los nuevos campos editoriales de decisión se agregan como opcionales en el esquema:
+  - `format_candidates`: `article` | `yt_script` | `both`
+  - `working_title`
+  - `angle`
+  - `why_now`
+  - `supporting_refs`
+  - `risk_notes`
+- Recomendación operativa: para nuevos flujos editoriales, poblar estos campos como mínimo para habilitar decisión de formato y priorización.
 
 ## External dependency boundary (explicit)
 - PromptFlow runtime/env/connectivity is an external dependency boundary for this module.

--- a/apps/news_editorial/runbook.md
+++ b/apps/news_editorial/runbook.md
@@ -20,7 +20,7 @@ PR4b establishes module ownership and a stable operator entrypoint while keeping
 
 ### Seams/exports targeted (future adapters)
 - `news_topic_cluster.v1`
-- `news_seed_idea.v1`
+- `news_seed_idea.v1` (expandido de forma backward-compatible con campos editoriales: `format_candidates`, `working_title`, `angle`, `why_now`, `supporting_refs`, `risk_notes`)
 - `news_seed_card.v1`
 
 
@@ -62,6 +62,18 @@ DIGEST_AT=20260313T15 PF_MODE=new apps/news_editorial/entrypoints/run_editorial_
 - `make s04` already performs no-op when suitable PF input is missing.
 - `make s05` continues with existing legacy behavior over available PF outputs.
 - This wrapper does not alter stage semantics; it only centralizes editorial ownership at module level.
+
+
+## Contrato editorial actualizado (`news_seed_idea.v1`)
+- Se mantiene **la misma versión `v1`** para preservar compatibilidad con productores/consumidores actuales.
+- Los nuevos campos editoriales de decisión se agregan como opcionales en el esquema:
+  - `format_candidates`: `article` | `yt_script` | `both`
+  - `working_title`
+  - `angle`
+  - `why_now`
+  - `supporting_refs`
+  - `risk_notes`
+- Recomendación operativa: para nuevos flujos editoriales, poblar estos campos como mínimo para habilitar decisión de formato y priorización.
 
 ## External dependency boundary
 - PromptFlow runtime (`PF_PYTHON`/conda env and run dir resolution) remains external dependency.

--- a/contracts/schemas/news_seed_idea.v1.json
+++ b/contracts/schemas/news_seed_idea.v1.json
@@ -6,17 +6,71 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "schema_name": { "const": "news_seed_idea.v1" },
-    "schema_status": { "const": "experimental_structured" },
-    "digest_group_id": { "type": "string", "minLength": 1 },
-    "idea_id": { "type": "string", "minLength": 1 },
-    "topic": { "type": "string", "minLength": 1 },
-    "headline": { "type": "string", "minLength": 1 },
-    "dek": { "type": "string" },
-    "rationale": { "type": "string" },
+    "schema_name": {
+      "const": "news_seed_idea.v1"
+    },
+    "schema_status": {
+      "const": "experimental_structured"
+    },
+    "digest_group_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "idea_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "topic": {
+      "type": "string",
+      "minLength": 1
+    },
+    "headline": {
+      "type": "string",
+      "minLength": 1
+    },
+    "format_candidates": {
+      "type": "string",
+      "enum": [
+        "article",
+        "yt_script",
+        "both"
+      ],
+      "description": "Formato editorial candidato para desarrollo del seed idea."
+    },
+    "working_title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "angle": {
+      "type": "string",
+      "minLength": 1
+    },
+    "why_now": {
+      "type": "string",
+      "minLength": 1
+    },
+    "supporting_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "risk_notes": {
+      "type": "string"
+    },
+    "dek": {
+      "type": "string"
+    },
+    "rationale": {
+      "type": "string"
+    },
     "supporting_article_ids": {
       "type": "array",
-      "items": { "type": "string", "minLength": 1 }
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
   "required": [

--- a/contracts/tests/fixtures/news_seed_idea.example.json
+++ b/contracts/tests/fixtures/news_seed_idea.example.json
@@ -5,6 +5,15 @@
   "idea_id": "idea-001",
   "topic": "Economia",
   "headline": "Qué implica la desaceleración de la inflación",
+  "format_candidates": "both",
+  "working_title": "Inflación en pausa: lo que cambia para hogares y pymes",
+  "angle": "Traducir señales macroeconómicas en decisiones cotidianas de consumo y crédito.",
+  "why_now": "Los últimos datos del IPC confirman una desaceleración que reordena expectativas de tasas.",
+  "supporting_refs": [
+    "https://www.bcra.gob.ar/Estadisticas",
+    "https://www.indec.gob.ar/indec/web/Nivel4-Tema-3-5-31"
+  ],
+  "risk_notes": "Evitar sobreprometer baja de precios; incluir diferencias por rubro y región.",
   "dek": "Análisis de efectos sobre consumo y crédito.",
   "rationale": "Se detecta convergencia temática en artículos líderes.",
   "supporting_article_ids": ["42", "73"]


### PR DESCRIPTION
### Motivation
- Añadir metadatos editoriales mínimos al contrato `news_seed_idea` para permitir decisiones de formato y priorización sin romper compatibilidad.
- Mantener interoperabilidad con productores y consumidores existentes evitando una nueva versión (`v2`).

### Description
- Se agregaron campos opcionales en `contracts/schemas/news_seed_idea.v1.json`: `format_candidates` (enum: `article`,`yt_script`,`both`), `working_title`, `angle`, `why_now`, `supporting_refs`, y `risk_notes`.
- Se actualizó el fixture de ejemplo en `contracts/tests/fixtures/news_seed_idea.example.json` para incluir un ejemplo que declara `"format_candidates": "both"` y rellena los nuevos campos.
- Se documentó la decisión de compatibilidad y el uso recomendado de los nuevos campos en `apps/news_editorial/README.md` y `apps/news_editorial/runbook.md`.
- La propiedad `required` del esquema no fue modificada, preservando validación backward-compatible.

### Testing
- Ejecutado `pytest -q contracts/tests/test_contracts.py` y las pruebas de contrato pasaron correctamente (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5975c33d4832d9c73b99883ee780f)