### PR TITLE
Unify seed_ideas key_facts contract across schema, prompt and downstream

### DIFF
--- a/apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py
+++ b/apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py
@@ -88,6 +88,25 @@ def iter_jsonl_records(path: Path) -> Iterable[dict]:
                 yield {"__bad__": True, "error": str(e), "line_no": ln, "line": s[:400]}
 
 # -------- Draft construction --------
+def normalize_seed_idea(idea: dict) -> dict:
+    """Normalize PF seed idea payload to canonical v1 keys."""
+    normalized = dict(idea or {})
+    if "key_facts" not in normalized and "key_data_points" in normalized:
+        normalized["key_facts"] = normalized.get("key_data_points")
+    return normalized
+
+
+def extract_seed_ideas(row: dict) -> list[dict]:
+    """Read seed ideas from PF output using canonical key names."""
+    seed_ideas_obj = row.get("seed_ideas")
+    if not isinstance(seed_ideas_obj, dict):
+        return []
+    ideas = seed_ideas_obj.get("seed_ideas")
+    if not isinstance(ideas, list):
+        return []
+    return [normalize_seed_idea(idea) for idea in ideas if isinstance(idea, dict)]
+
+
 def build_citation(link: str, title: str, source: str) -> dict:
     # minimal citation contract; validator will enforce stricter if available
     return {"url": link, "title": title, "source": source}
@@ -334,9 +353,10 @@ def run() -> int:
                         # best-effort log; pipeline still proceeds
                         bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "enqueue_not_available", "stage": "generate", "work_key": index_id, "payload": payload})
 
-        # You can also process seed_ideas here if you want to persist them:
-        # ideas = row.get("seed_ideas", {}).get("seed_ideas", []) if isinstance(row.get("seed_ideas"), dict) else []
-        # (Persist to a separate ideas/ path if helpful.)
+        # Canonical PF contract key: seed_ideas[*].key_facts
+        # (legacy alias key_data_points is normalized to key_facts in extract_seed_ideas).
+        ideas = extract_seed_ideas(row)
+        # (Persist ideas to a separate path if needed by downstream products.)
 
     # Join success threshold
     if total_refs > 0:

--- a/flow/02_generate_agenda_and_ideas.json
+++ b/flow/02_generate_agenda_and_ideas.json
@@ -53,7 +53,7 @@
             "idea_title",
             "source_ids",
             "draft_editorial_angle",
-            "key_data_points",
+            "key_facts",
             "potential_controversies",
             "relevant_quotes"
           ]

--- a/flow/news.agenda.generate.seed_ideas.v1.jinja2
+++ b/flow/news.agenda.generate.seed_ideas.v1.jinja2
@@ -3,6 +3,8 @@ Eres un asistente en el Laboratorio de Automatización de Matías (MAL). Tu func
 
 Utiliza el esquema JSON proporcionado denominado `generate_agenda_and_ideas` para estructurar tu respuesta. Concéntrate en identificar los puntos más noticiosos, relevantes o controvertidos que podrían orientar el desarrollo de futuros artículos. Mantén tus ideas claras y orientadas a la acción.
 
+Cada objeto dentro de `seed_ideas` debe incluir exactamente estas claves: `idea_id`, `topic`, `idea_title`, `source_ids`, `draft_editorial_angle`, `key_facts`, `potential_controversies`, `relevant_quotes`.
+
 No incluyas explicaciones ni texto adicional fuera del JSON estructurado.
 
 ---

--- a/tests/test_pf_seed_ideas_contract.py
+++ b/tests/test_pf_seed_ideas_contract.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError, validate
+
+
+def _load_schema() -> dict:
+    schema_path = Path(__file__).resolve().parents[1] / "flow" / "02_generate_agenda_and_ideas.json"
+    return json.loads(schema_path.read_text(encoding="utf-8"))["parameters"]
+
+
+def test_seed_ideas_payload_matches_pf_schema_contract() -> None:
+    schema = _load_schema()
+    payload = {
+        "seed_ideas": [
+            {
+                "idea_id": "EC01",
+                "topic": "Economía",
+                "idea_title": "Inflación y consumo: señales de enfriamiento",
+                "source_ids": [101, 102],
+                "draft_editorial_angle": "El consumo muestra señales mixtas pese a una inflación más estable.",
+                "key_facts": [
+                    "La inflación interanual se desaceleró al 3.2%.",
+                    "Las ventas minoristas cayeron 1.1% mensual.",
+                ],
+                "potential_controversies": [
+                    "Debate sobre efecto real de tasas altas en pymes",
+                ],
+                "relevant_quotes": [
+                    "El mercado aún no percibe mejora en ingresos reales.",
+                ],
+            }
+        ]
+    }
+
+    validate(instance=payload, schema=schema)
+
+
+def test_seed_ideas_payload_rejects_legacy_key_data_points() -> None:
+    schema = _load_schema()
+    payload = {
+        "seed_ideas": [
+            {
+                "idea_id": "EC01",
+                "topic": "Economía",
+                "idea_title": "Inflación y consumo: señales de enfriamiento",
+                "source_ids": [101],
+                "draft_editorial_angle": "Ángulo editorial de prueba.",
+                "key_data_points": ["dato legacy"],
+                "potential_controversies": ["controversia"],
+                "relevant_quotes": ["cita"],
+            }
+        ]
+    }
+
+    with pytest.raises(ValidationError):
+        validate(instance=payload, schema=schema)


### PR DESCRIPTION
### Motivation

- The PF schema listed a required key `key_data_points` that did not match the `properties` entry `key_facts`, causing contract drift.
- The PromptFlow prompt did not explicitly steer the LLM to output the canonical `key_facts` key.
- Downstream consumer code did not canonicalize legacy payloads, risking runtime mismatches when PF outputs used the old key.
- A contract test was needed to prevent regressions and ensure the schema enforces the canonical key.

### Description

- Updated the schema at `flow/02_generate_agenda_and_ideas.json` to require `key_facts` (replacing the inconsistent `key_data_points`).
- Added a clarifying sentence to the prompt `flow/news.agenda.generate.seed_ideas.v1.jinja2` that enumerates the exact keys expected in each `seed_ideas` object including `key_facts`.
- Implemented `normalize_seed_idea` and `extract_seed_ideas` in `apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py` to read canonical `seed_ideas` and normalize legacy `key_data_points` -> `key_facts` for compatibility.
- Added a new contract unit test `tests/test_pf_seed_ideas_contract.py` that validates a canonical payload against the schema and asserts a legacy payload with `key_data_points` is rejected.

### Testing

- Ran `pytest -q tests/test_pf_seed_ideas_contract.py tests/test_models.py` and all tests passed (`4 passed`).
- The repository contains `jsonschema` available in the environment and the new test exercises the JSON schema validation using `jsonschema.validate`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5981b0d80832db20ca1ad40af5ae8)