### PR TITLE
Add stage06 to build news_piece_briefs and make stage05 brief-first with legacy fallback

### DIFF
--- a/apps/news_editorial/README.md
+++ b/apps/news_editorial/README.md
@@ -28,6 +28,7 @@ This PR is additive: it clarifies ownership and operator entrypoints while prese
 ## Implementation location (PR4d)
 Editorial primary implementation now lives under:
 - `apps/news_editorial/src/news_editorial/stage04_promptflow_run.py`
+- `apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py`
 - `apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py`
 - `apps/news_editorial/src/news_editorial/{ids,io,db,slugs}.py`
 
@@ -47,7 +48,8 @@ apps/news_editorial/entrypoints/run_editorial_owner.sh
 
 Wrapper delegates to canonical runtime targets:
 1. `make s04`
-2. `make s05`
+2. `make s06`
+3. `make s05`
 
 
 ## Contrato editorial actualizado (`news_seed_idea.v1`)

--- a/apps/news_editorial/entrypoints/run_editorial_owner.sh
+++ b/apps/news_editorial/entrypoints/run_editorial_owner.sh
@@ -14,7 +14,7 @@ run_editorial_owner.sh
 
 Editorial owner wrapper (PR4b).
 - Keeps canonical runtime intact by delegating to existing make targets.
-- Orchestrates editorial layer only: s04 -> s05.
+- Orchestrates editorial layer only: s04 -> s06 -> s05.
 
 Env knobs:
   DIGEST_AT  Hour bucket (YYYYMMDDTHH). Default: current UTC hour.
@@ -45,5 +45,6 @@ run_cmd() {
 
 echo "[editorial-owner] digest_at=${DIGEST_AT} dry_run=${DRY_RUN} pf_mode=${PF_MODE}"
 run_cmd make s04 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN" PF_MODE="$PF_MODE"
+run_cmd make s06 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
 run_cmd make s05 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
 echo "[editorial-owner] done"

--- a/apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py
+++ b/apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py
@@ -1,5 +1,5 @@
 # legacy/05_explode_pf_outputs.py
-# Explode PF clusters -> ArticleDraftV1, validate, and enqueue "generate".
+# Explode PF clusters or briefs -> ArticleDraftV1, validate, and enqueue "generate".
 from __future__ import annotations
 
 import os
@@ -7,12 +7,13 @@ import re
 import sys
 import json
 from pathlib import Path
-from typing import Iterable, List, Dict, Tuple, Optional
+from typing import Iterable, List, Tuple, Optional
 
 import pandas as pd
 
 from . import ids, db, slugs
 from . import io as bio
+
 try:
     # Optional strict validation if your models are wired
     from backend.models import ArticleDraftV1  # type: ignore
@@ -21,10 +22,13 @@ except Exception:
 
 # -------- Paths --------
 DATA_DIR = Path(os.getenv("DATA_DIR", "data"))
+STORAGE_DIR = Path(os.getenv("STORAGE_DIR", "storage"))
 PF_OUT_DIR = DATA_DIR / "pf_out"
 DIGEST_MAP_DIR = DATA_DIR / "digest_map"
 DRAFTS_BASE = DATA_DIR / "drafts"
 QUAR_DIR = DATA_DIR / "quarantine"
+BRIEFS_DIR = STORAGE_DIR / "buses" / "news_piece_brief" / "v1"
+
 
 # -------- Env helpers --------
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -32,6 +36,7 @@ def _env_bool(name: str, default: bool = False) -> bool:
     if v is None:
         return default
     return v.strip() not in ("0", "false", "False", "")
+
 
 def _env_float(name: str, default: float | None = None) -> float | None:
     v = os.getenv(name)
@@ -42,12 +47,15 @@ def _env_float(name: str, default: float | None = None) -> float | None:
     except Exception:
         return default
 
+
 def ensure_dirs():
-    for p in (PF_OUT_DIR, DIGEST_MAP_DIR, DRAFTS_BASE, QUAR_DIR):
+    for p in (PF_OUT_DIR, DIGEST_MAP_DIR, DRAFTS_BASE, QUAR_DIR, BRIEFS_DIR):
         p.mkdir(parents=True, exist_ok=True)
+
 
 def quarantine_path(stage: str, run_id: str) -> Path:
     return QUAR_DIR / f"{stage}_{run_id}.jsonl"
+
 
 def atomic_write_one_jsonl(path: Path, record: dict) -> None:
     """Idempotent write of a single-record JSONL file."""
@@ -55,26 +63,39 @@ def atomic_write_one_jsonl(path: Path, record: dict) -> None:
     line = json.dumps(record, ensure_ascii=False)
     bio.atomic_write_jsonl(path, [line])
 
+
 # -------- Parsing helpers --------
 _GROUP_ID_RE = re.compile(r"^(?P<ts>\d{8}T\d{2})::(?P<win>[A-Za-z0-9_]+)::(?P<topic>.+?)::(?P<grp>\d{2})$")
 
+
 def parse_digest_group_id(digest_group_id: str) -> Optional[Tuple[str, str, str, str]]:
-    """
-    Returns (digest_ts, window_type, topic_slug_or_name, group_no) or None.
-    """
     m = _GROUP_ID_RE.match(digest_group_id or "")
     if not m:
         return None
     return m.group("ts"), m.group("win"), m.group("topic"), m.group("grp")
 
+
 def derive_digest_file(digest_ts: str, window_type: str) -> str:
-    # 02 produced digest_file names like "<window>_<YYYYMMDDTHH>00"
     return f"{window_type}_{digest_ts}00"
 
+
 def load_pf_outputs_for_hour(digest_id: str) -> List[Path]:
-    # support both pfout_<HOUR>.jsonl and pfout_<HOUR>_*.jsonl
-    paths = sorted(PF_OUT_DIR.glob(f"pfout_{digest_id}*.jsonl"))
-    return paths
+    return sorted(PF_OUT_DIR.glob(f"pfout_{digest_id}*.jsonl"))
+
+
+def load_piece_briefs_for_hour(digest_id: str) -> list[dict]:
+    rows: list[dict] = []
+    for path in sorted(BRIEFS_DIR.glob("*.jsonl")):
+        for rec in iter_jsonl_records(path):
+            if rec.get("__bad__"):
+                continue
+            if str(rec.get("schema_name") or "").strip() != "news_piece_brief.v1":
+                continue
+            if str(rec.get("digest_id_hour") or "").strip() != digest_id:
+                continue
+            rows.append(rec)
+    return rows
+
 
 def iter_jsonl_records(path: Path) -> Iterable[dict]:
     with path.open("r", encoding="utf-8") as f:
@@ -87,9 +108,9 @@ def iter_jsonl_records(path: Path) -> Iterable[dict]:
             except Exception as e:
                 yield {"__bad__": True, "error": str(e), "line_no": ln, "line": s[:400]}
 
+
 # -------- Draft construction --------
 def normalize_seed_idea(idea: dict) -> dict:
-    """Normalize PF seed idea payload to canonical v1 keys."""
     normalized = dict(idea or {})
     if "key_facts" not in normalized and "key_data_points" in normalized:
         normalized["key_facts"] = normalized.get("key_data_points")
@@ -97,7 +118,6 @@ def normalize_seed_idea(idea: dict) -> dict:
 
 
 def extract_seed_ideas(row: dict) -> list[dict]:
-    """Read seed ideas from PF output using canonical key names."""
     seed_ideas_obj = row.get("seed_ideas")
     if not isinstance(seed_ideas_obj, dict):
         return []
@@ -108,41 +128,35 @@ def extract_seed_ideas(row: dict) -> list[dict]:
 
 
 def build_citation(link: str, title: str, source: str) -> dict:
-    # minimal citation contract; validator will enforce stricter if available
     return {"url": link, "title": title, "source": source}
 
-def make_draft_obj(digest_id: str,
-                   digest_file: str,
-                   article_id: str,
-                   index_id: str,
-                   cluster_topic: str | None,
-                   mapped_row: dict,
-                   headline: str | None) -> dict:
-    # Conservative, minimal draft; ArticleDraftV1 (if present) will validate/transform.
+
+def make_draft_obj(
+    digest_id: str,
+    digest_file: str,
+    article_id: str,
+    index_id: str,
+    cluster_topic: str | None,
+    mapped_row: dict,
+    headline: str | None,
+) -> dict:
     title = headline or str(mapped_row.get("Title") or "").strip()
     source = str(mapped_row.get("Source") or "").strip()
     link = str(mapped_row.get("Link") or "").strip()
-
-    # Stable identities
-    cluster_id = f"{digest_id}:{index_id}"      # per-hour × per-entity
+    cluster_id = f"{digest_id}:{index_id}"
     slug = slugs.slugify(title) or index_id.lower()
 
-    draft = {
+    return {
         "digest_id_hour": digest_id,
         "digest_file": digest_file,
         "article_id": str(article_id),
         "index_id": index_id,
-
         "topic": (cluster_topic or str(mapped_row.get("Topic") or "All Topics")).strip(),
         "headline": title,
-        "dek": None,  # could be filled from PF "seed_ideas" if you prefer
-
+        "dek": None,
         "citations": [build_citation(link, title, source)] if link else [],
-
         "cluster_id": cluster_id,
         "slug": slug,
-
-        # allow downstream generator to fill these:
         "body_html": "",
         "tags": [],
         "related_ids": [],
@@ -151,21 +165,93 @@ def make_draft_obj(digest_id: str,
             "first_seen": str(mapped_row.get("Published", "")),
         },
     }
-    return draft
+
+
+def make_draft_obj_from_brief(brief: dict, mapped_by_index: dict[str, dict]) -> tuple[dict | None, str | None]:
+    index_ids = [str(v).strip() for v in (brief.get("source_index_ids") or []) if str(v).strip()]
+    if not index_ids:
+        index_ids = [str(r.get("index_id") or "").strip() for r in (brief.get("source_refs") or []) if isinstance(r, dict)]
+        index_ids = [v for v in index_ids if v]
+    if not index_ids:
+        return None, "brief_without_sources"
+
+    primary_index_id = index_ids[0]
+    primary = mapped_by_index.get(primary_index_id)
+    if not primary:
+        return None, "brief_primary_index_missing"
+
+    citations = []
+    for idx in index_ids:
+        row = mapped_by_index.get(idx)
+        if not row:
+            continue
+        link = str(row.get("Link") or "").strip()
+        if not link:
+            continue
+        title = str(row.get("Title") or "").strip()
+        source = str(row.get("Source") or "").strip()
+        citations.append(build_citation(link, title, source))
+
+    digest_file = str(brief.get("digest_file") or primary.get("digest_file") or "").strip()
+    digest_id_hour = str(brief.get("digest_id_hour") or "").strip()
+
+    return {
+        "digest_id_hour": digest_id_hour,
+        "digest_file": digest_file,
+        "article_id": str(primary.get("article_id") or "").strip(),
+        "index_id": primary_index_id,
+        "topic": str(brief.get("topic") or primary.get("Topic") or "All Topics").strip(),
+        "headline": str(brief.get("working_title") or primary.get("Title") or "").strip(),
+        "dek": str(brief.get("angle") or "").strip() or None,
+        "citations": citations,
+        "cluster_id": str(brief.get("brief_id") or f"brief:{primary_index_id}"),
+        "slug": slugs.slugify(str(brief.get("working_title") or primary.get("Title") or "")) or primary_index_id.lower(),
+        "body_html": "",
+        "tags": [],
+        "related_ids": index_ids[1:],
+        "meta": {
+            "source": str(primary.get("Source") or "").strip(),
+            "first_seen": str(primary.get("Published") or ""),
+            "brief_id": str(brief.get("brief_id") or "").strip(),
+            "brief_schema": str(brief.get("schema_name") or "").strip(),
+        },
+    }, None
+
+
+def _validate_and_package_draft(draft_obj: dict, run_id: str, source_reason: str) -> tuple[dict | None, str | None]:
+    has_headline = bool(draft_obj.get("headline"))
+    has_dek = bool(draft_obj.get("dek"))
+    cits = draft_obj.get("citations") or []
+    ok_min = bool(draft_obj.get("topic")) and (has_headline or has_dek) and any(c.get("url") for c in cits)
+    if not ok_min:
+        return None, "validation_min_fail"
+
+    if ArticleDraftV1 is not None:
+        try:
+            draft_model = ArticleDraftV1(**draft_obj)
+            return json.loads(draft_model.model_dump_json()), None
+        except Exception as e:
+            bio.append_jsonl(quarantine_path("V05", run_id), {
+                "reason": "pydantic_validation_error",
+                "error": str(e),
+                "source_reason": source_reason,
+                "draft": draft_obj,
+            })
+            return None, "pydantic_validation_error"
+    return draft_obj, None
+
 
 # -------- Core --------
 def run() -> int:
     ensure_dirs()
 
-    # Env knobs
-    digest_at_env = os.getenv("DIGEST_AT")  # YYYYMMDDTHH
+    digest_at_env = os.getenv("DIGEST_AT")
     dry_run = _env_bool("DRY_RUN", False)
-    null_sink = _env_bool("NULL_SINK", False)  # drafts path supports null sink at directory level
+    null_sink = _env_bool("NULL_SINK", False)
     run_id = os.getenv("RUN_ID")
-    limit = _env_float("LIMIT", None)   # cap PF groups processed
-    sample = _env_float("SAMPLE", None) # frac of PF groups
+    limit = _env_float("LIMIT", None)
+    sample = _env_float("SAMPLE", None)
 
-    # Derive hour
     if digest_at_env:
         digest_id, _ = ids.digest_id_hour(digest_at_env)
     else:
@@ -173,17 +259,14 @@ def run() -> int:
     stage_name = "05_explode_pf_outputs"
     run_id = run_id or f"{stage_name}:{digest_id}"
 
-    # Start run
     try:
         db.start_run(run_id, stage_name, {"digest_id": digest_id})
     except Exception:
         pass
 
-    # Load mapping for the hour
     map_csv = DIGEST_MAP_DIR / f"{digest_id}.csv"
     if not map_csv.exists():
-        msg = {"note": "no digest_map", "digest_id": digest_id}
-        bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "missing_digest_map", **msg})
+        bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "missing_digest_map", "digest_id": digest_id})
         try:
             db.finish_run(run_id, ok=0, fail=1)
         except Exception:
@@ -201,7 +284,6 @@ def run() -> int:
             pass
         return 1
 
-    # Build key->row map: key = digest_file::article_id
     required_cols = ["digest_file", "article_id", "index_id", "Title", "Source", "Link", "Published"]
     missing = [c for c in required_cols if c not in df_map.columns]
     if missing:
@@ -213,10 +295,9 @@ def run() -> int:
         return 1
 
     df_map["article_id"] = df_map["article_id"].astype(str)
-    kseries = df_map["digest_file"].astype(str) + "::" + df_map["article_id"].astype(str)
-    map_rows = df_map.assign(_key=kseries).set_index("_key").to_dict(orient="index")
+    map_rows = df_map.assign(_key=df_map["digest_file"].astype(str) + "::" + df_map["article_id"].astype(str)).set_index("_key").to_dict(orient="index")
+    mapped_by_index = df_map.assign(index_id=df_map["index_id"].astype(str)).set_index("index_id").to_dict(orient="index")
 
-    # PF outputs
     pf_files = load_pf_outputs_for_hour(digest_id)
     if not pf_files:
         print(f"[{stage_name}] no PF outputs for {digest_id} in {PF_OUT_DIR}")
@@ -226,7 +307,6 @@ def run() -> int:
             pass
         return 0
 
-    # Read, optionally sample/limit at the GROUP (line) level
     group_records: List[dict] = []
     for pf in pf_files:
         for rec in iter_jsonl_records(pf):
@@ -249,127 +329,124 @@ def run() -> int:
     if limit is not None:
         df_groups = df_groups.head(int(limit))
 
-    # Output drafts directory
     drafts_dir = (DATA_DIR / "_tmp" / "null" / "drafts" / digest_id) if null_sink else (DRAFTS_BASE / digest_id)
     drafts_dir.mkdir(parents=True, exist_ok=True)
 
-    # Explode clusters
-    total_refs = 0  # how many (digest_file, article_id) refs PF tried to produce
+    total_refs = 0
     joined_refs = 0
     ok_drafts = 0
     bad_drafts = 0
 
-    for _, row in df_groups.iterrows():
-        digest_group_id = str(row.get("digest_group_id", "") or "").strip()
-        parsed = parse_digest_group_id(digest_group_id)
-        if not parsed:
-            bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "bad_digest_group_id", "value": digest_group_id})
-            bad_drafts += 1
-            continue
-        digest_ts, window_type, topic_str, group_no = parsed
-        digest_file = derive_digest_file(digest_ts, window_type)
+    briefs = load_piece_briefs_for_hour(digest_id)
+    use_briefs = len(briefs) > 0
 
-        # clusters structure: legacy: {"clustered_agenda_table": [{"topic": "...", "article_ids":[...], "deduplicated_titles":[...]}]}
-        clusters_obj = row.get("clustered_agenda_table", {})
-        if isinstance(clusters_obj, dict) and "clustered_agenda_table" in clusters_obj:
-            clusters = clusters_obj.get("clustered_agenda_table") or []
-        elif isinstance(clusters_obj, list):
-            clusters = clusters_obj
-        else:
-            clusters = []
+    if use_briefs:
+        for brief in briefs:
+            total_refs += 1
+            draft_obj, err = make_draft_obj_from_brief(brief, mapped_by_index)
+            if err or draft_obj is None:
+                bio.append_jsonl(quarantine_path("V05", run_id), {"reason": err or "brief_packaging_error", "brief_id": brief.get("brief_id")})
+                bad_drafts += 1
+                continue
 
-        if not clusters:
-            # still allow seed ideas path below; but note no article refs here
-            pass
+            draft_record, validation_err = _validate_and_package_draft(draft_obj, run_id, "brief")
+            if validation_err or draft_record is None:
+                bad_drafts += 1
+                continue
 
-        for cl in clusters:
-            cl_topic = cl.get("topic") if isinstance(cl, dict) else None
-            a_ids = (cl.get("article_ids") or []) if isinstance(cl, dict) else []
-            titles = (cl.get("deduplicated_titles") or []) if isinstance(cl, dict) else []
+            index_id = str(draft_record.get("index_id") or "").strip()
+            out_path = drafts_dir / f"{index_id}.jsonl"
+            atomic_write_one_jsonl(out_path, draft_record)
+            ok_drafts += 1
+            joined_refs += 1
 
-            n = min(len(a_ids), len(titles)) if titles else len(a_ids)
-            for i in range(n):
-                article_id = str(a_ids[i])
-                headline = titles[i] if i < len(titles) else None
-
-                total_refs += 1
-                key = f"{digest_file}::{article_id}"
-                mapped = map_rows.get(key)
-                if not mapped:
-                    bio.append_jsonl(quarantine_path("V05", run_id), {
-                        "reason": "map_miss",
-                        "digest_file": digest_file,
-                        "article_id": article_id,
-                        "key": key
-                    })
-                    bad_drafts += 1
-                    continue
-
-                index_id = str(mapped.get("index_id"))
-                draft_obj = make_draft_obj(digest_ts, digest_file, article_id, index_id, cl_topic, mapped, headline)
-
-                # Validation (V05): topic && (headline||dek) && >=1 citation.url
-                has_headline = bool(draft_obj.get("headline"))
-                has_dek = bool(draft_obj.get("dek"))
-                cits = draft_obj.get("citations") or []
-                ok_min = bool(draft_obj.get("topic")) and (has_headline or has_dek) and any(c.get("url") for c in cits)
-
-                if not ok_min:
-                    bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "validation_min_fail", "draft": draft_obj})
-                    bad_drafts += 1
-                    continue
-
-                # Optional strict Pydantic validation
-                if ArticleDraftV1 is not None:
+            if not dry_run:
+                payload = {"digest_id_hour": draft_record.get("digest_id_hour"), "index_id": index_id, "draft_path": str(out_path)}
+                enqueued = False
+                for fn in ("push_work", "push_job", "enqueue_work", "enqueue_job"):
                     try:
-                        draft_model = ArticleDraftV1(**draft_obj)
-                        draft_record = json.loads(draft_model.model_dump_json())
-                    except Exception as e:
-                        bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "pydantic_validation_error", "error": str(e), "draft": draft_obj})
+                        getattr(db, fn)("generate", index_id, json.dumps(payload))
+                        enqueued = True
+                        break
+                    except Exception:
+                        continue
+                if not enqueued:
+                    bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "enqueue_not_available", "stage": "generate", "work_key": index_id, "payload": payload})
+    else:
+        warning = (
+            f"[{stage_name}] WARNING no news_piece_brief.v1 found for digest_id={digest_id}; "
+            "falling back to legacy cluster packaging path"
+        )
+        print(warning)
+        bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "missing_piece_briefs_fallback_legacy", "digest_id": digest_id})
+
+        for _, row in df_groups.iterrows():
+            digest_group_id = str(row.get("digest_group_id", "") or "").strip()
+            parsed = parse_digest_group_id(digest_group_id)
+            if not parsed:
+                bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "bad_digest_group_id", "value": digest_group_id})
+                bad_drafts += 1
+                continue
+
+            digest_ts, window_type, _, _ = parsed
+            digest_file = derive_digest_file(digest_ts, window_type)
+            clusters_obj = row.get("clustered_agenda_table", {})
+            if isinstance(clusters_obj, dict) and "clustered_agenda_table" in clusters_obj:
+                clusters = clusters_obj.get("clustered_agenda_table") or []
+            elif isinstance(clusters_obj, list):
+                clusters = clusters_obj
+            else:
+                clusters = []
+
+            for cl in clusters:
+                cl_topic = cl.get("topic") if isinstance(cl, dict) else None
+                a_ids = (cl.get("article_ids") or []) if isinstance(cl, dict) else []
+                titles = (cl.get("deduplicated_titles") or []) if isinstance(cl, dict) else []
+
+                n = min(len(a_ids), len(titles)) if titles else len(a_ids)
+                for i in range(n):
+                    article_id = str(a_ids[i])
+                    headline = titles[i] if i < len(titles) else None
+
+                    total_refs += 1
+                    key = f"{digest_file}::{article_id}"
+                    mapped = map_rows.get(key)
+                    if not mapped:
+                        bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "map_miss", "digest_file": digest_file, "article_id": article_id, "key": key})
                         bad_drafts += 1
                         continue
-                else:
-                    draft_record = draft_obj
 
-                # Idempotent write per index_id
-                out_path = drafts_dir / f"{index_id}.jsonl"
-                atomic_write_one_jsonl(out_path, draft_record)
-                ok_drafts += 1
-                joined_refs += 1
+                    index_id = str(mapped.get("index_id"))
+                    draft_obj = make_draft_obj(digest_ts, digest_file, article_id, index_id, cl_topic, mapped, headline)
+                    draft_record, validation_err = _validate_and_package_draft(draft_obj, run_id, "cluster")
+                    if validation_err or draft_record is None:
+                        bad_drafts += 1
+                        continue
 
-                # Enqueue next stage
-                if not dry_run:
-                    # Try a few possible enqueue APIs depending on your backend
-                    payload = {"digest_id_hour": digest_ts, "index_id": index_id, "draft_path": str(out_path)}
-                    enqueued = False
-                    for fn in ("push_work", "push_job", "enqueue_work", "enqueue_job"):
-                        try:
-                            getattr(db, fn)("generate", index_id, json.dumps(payload))
-                            enqueued = True
-                            break
-                        except Exception:
-                            continue
-                    if not enqueued:
-                        # best-effort log; pipeline still proceeds
-                        bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "enqueue_not_available", "stage": "generate", "work_key": index_id, "payload": payload})
+                    out_path = drafts_dir / f"{index_id}.jsonl"
+                    atomic_write_one_jsonl(out_path, draft_record)
+                    ok_drafts += 1
+                    joined_refs += 1
 
-        # Canonical PF contract key: seed_ideas[*].key_facts
-        # (legacy alias key_data_points is normalized to key_facts in extract_seed_ideas).
-        ideas = extract_seed_ideas(row)
-        # (Persist ideas to a separate path if needed by downstream products.)
+                    if not dry_run:
+                        payload = {"digest_id_hour": digest_ts, "index_id": index_id, "draft_path": str(out_path)}
+                        enqueued = False
+                        for fn in ("push_work", "push_job", "enqueue_work", "enqueue_job"):
+                            try:
+                                getattr(db, fn)("generate", index_id, json.dumps(payload))
+                                enqueued = True
+                                break
+                            except Exception:
+                                continue
+                        if not enqueued:
+                            bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "enqueue_not_available", "stage": "generate", "work_key": index_id, "payload": payload})
 
-    # Join success threshold
+            _ = extract_seed_ideas(row)
+
     if total_refs > 0:
         join_ratio = joined_refs / total_refs
         if join_ratio < 0.99:
-            # fail hard per spec
-            bio.append_jsonl(quarantine_path("V05", run_id), {
-                "reason": "join_ratio_below_threshold",
-                "joined": joined_refs,
-                "total": total_refs,
-                "ratio": round(join_ratio, 4),
-                "threshold": 0.99
-            })
+            bio.append_jsonl(quarantine_path("V05", run_id), {"reason": "join_ratio_below_threshold", "joined": joined_refs, "total": total_refs, "ratio": round(join_ratio, 4), "threshold": 0.99})
             try:
                 db.finish_run(run_id, ok=ok_drafts, fail=bad_drafts + 1)
             except Exception:
@@ -377,7 +454,6 @@ def run() -> int:
             print(f"[{stage_name}] join ratio {join_ratio:.3%} < 99% — fail")
             return 2
 
-    # Finish run
     try:
         db.finish_run(run_id, ok=ok_drafts, fail=bad_drafts)
     except Exception:

--- a/apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py
+++ b/apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, Optional, Tuple
+
+import pandas as pd
+
+from . import db, ids
+from . import io as bio
+
+DATA_DIR = Path(os.getenv("DATA_DIR", "data"))
+PF_OUT_DIR = DATA_DIR / "pf_out"
+DIGEST_MAP_DIR = DATA_DIR / "digest_map"
+QUAR_DIR = DATA_DIR / "quarantine"
+STORAGE_DIR = Path(os.getenv("STORAGE_DIR", "storage"))
+BRIEFS_DIR = STORAGE_DIR / "buses" / "news_piece_brief" / "v1"
+
+_GROUP_ID_RE = re.compile(r"^(?P<ts>\d{8}T\d{2})::(?P<win>[A-Za-z0-9_]+)::(?P<topic>.+?)::(?P<grp>\d{2})$")
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    v = os.getenv(name)
+    if v is None:
+        return default
+    return v.strip() not in ("0", "false", "False", "")
+
+
+def ensure_dirs() -> None:
+    for p in (PF_OUT_DIR, DIGEST_MAP_DIR, QUAR_DIR, BRIEFS_DIR):
+        p.mkdir(parents=True, exist_ok=True)
+
+
+def quarantine_path(stage: str, run_id: str) -> Path:
+    return QUAR_DIR / f"{stage}_{run_id}.jsonl"
+
+
+def atomic_write_one_jsonl(path: Path, record: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(record, ensure_ascii=False)
+    bio.atomic_write_jsonl(path, [line])
+
+
+def parse_digest_group_id(digest_group_id: str) -> Optional[Tuple[str, str, str, str]]:
+    m = _GROUP_ID_RE.match(digest_group_id or "")
+    if not m:
+        return None
+    return m.group("ts"), m.group("win"), m.group("topic"), m.group("grp")
+
+
+def derive_digest_file(digest_ts: str, window_type: str) -> str:
+    return f"{window_type}_{digest_ts}00"
+
+
+def load_pf_outputs_for_hour(digest_id: str) -> list[Path]:
+    return sorted(PF_OUT_DIR.glob(f"pfout_{digest_id}*.jsonl"))
+
+
+def iter_jsonl_records(path: Path) -> Iterable[dict]:
+    with path.open("r", encoding="utf-8") as f:
+        for ln, line in enumerate(f, start=1):
+            s = line.strip()
+            if not s:
+                continue
+            try:
+                yield json.loads(s)
+            except Exception as e:
+                yield {"__bad__": True, "error": str(e), "line_no": ln, "line": s[:400]}
+
+
+def normalize_seed_idea(idea: dict) -> dict:
+    normalized = dict(idea or {})
+    if "key_facts" not in normalized and "key_data_points" in normalized:
+        normalized["key_facts"] = normalized.get("key_data_points")
+    return normalized
+
+
+def extract_seed_ideas(row: dict) -> list[dict]:
+    seed_ideas_obj = row.get("seed_ideas")
+    if not isinstance(seed_ideas_obj, dict):
+        return []
+    ideas = seed_ideas_obj.get("seed_ideas")
+    if not isinstance(ideas, list):
+        return []
+    return [normalize_seed_idea(idea) for idea in ideas if isinstance(idea, dict)]
+
+
+def _brief_id(digest_id: str, digest_group_id: str, idea: dict, ordinal: int) -> str:
+    idea_id = str(idea.get("idea_id") or "").strip() or f"{ordinal:02d}"
+    raw = f"{digest_id}|{digest_group_id}|{idea_id}"
+    digest = hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
+    return f"npb_{digest}"
+
+
+def run() -> int:
+    ensure_dirs()
+
+    digest_at_env = os.getenv("DIGEST_AT")
+    dry_run = _env_bool("DRY_RUN", False)
+    run_id = os.getenv("RUN_ID")
+
+    if digest_at_env:
+        digest_id, _ = ids.digest_id_hour(digest_at_env)
+    else:
+        digest_id, _ = ids.digest_id_hour(pd.Timestamp.utcnow().strftime("%Y%m%dT%H"))
+
+    stage_name = "06_build_piece_briefs"
+    run_id = run_id or f"{stage_name}:{digest_id}"
+
+    try:
+        db.start_run(run_id, stage_name, {"digest_id": digest_id})
+    except Exception:
+        pass
+
+    map_csv = DIGEST_MAP_DIR / f"{digest_id}.csv"
+    if not map_csv.exists():
+        bio.append_jsonl(quarantine_path("V06", run_id), {"reason": "missing_digest_map", "digest_id": digest_id})
+        try:
+            db.finish_run(run_id, ok=0, fail=1)
+        except Exception:
+            pass
+        return 1
+
+    try:
+        df_map = pd.read_csv(map_csv, dtype={"article_id": str})
+    except Exception as e:
+        bio.append_jsonl(quarantine_path("V06", run_id), {"reason": "map_read_error", "error": str(e), "file": str(map_csv)})
+        try:
+            db.finish_run(run_id, ok=0, fail=1)
+        except Exception:
+            pass
+        return 1
+
+    required_cols = ["digest_file", "article_id", "index_id", "Title", "Source", "Link", "Published"]
+    missing = [c for c in required_cols if c not in df_map.columns]
+    if missing:
+        bio.append_jsonl(quarantine_path("V06", run_id), {"reason": "map_missing_cols", "missing": missing})
+        try:
+            db.finish_run(run_id, ok=0, fail=1)
+        except Exception:
+            pass
+        return 1
+
+    df_map["article_id"] = df_map["article_id"].astype(str)
+    key_series = df_map["digest_file"].astype(str) + "::" + df_map["article_id"].astype(str)
+    map_rows = df_map.assign(_key=key_series).set_index("_key").to_dict(orient="index")
+
+    pf_files = load_pf_outputs_for_hour(digest_id)
+    if not pf_files:
+        print(f"[{stage_name}] no PF outputs for {digest_id}")
+        try:
+            db.finish_run(run_id, ok=0, fail=0)
+        except Exception:
+            pass
+        return 0
+
+    ok_briefs = 0
+    bad_briefs = 0
+
+    for pf in pf_files:
+        for row in iter_jsonl_records(pf):
+            if row.get("__bad__"):
+                bio.append_jsonl(quarantine_path("V06", run_id), {"reason": "pf_bad_jsonl", "file": pf.name, **row})
+                bad_briefs += 1
+                continue
+
+            digest_group_id = str(row.get("digest_group_id", "") or "").strip()
+            parsed = parse_digest_group_id(digest_group_id)
+            if not parsed:
+                bio.append_jsonl(quarantine_path("V06", run_id), {"reason": "bad_digest_group_id", "value": digest_group_id})
+                bad_briefs += 1
+                continue
+
+            digest_ts, window_type, topic_str, group_no = parsed
+            digest_file = derive_digest_file(digest_ts, window_type)
+
+            for ordinal, idea in enumerate(extract_seed_ideas(row), start=1):
+                source_ids = [str(v) for v in (idea.get("source_ids") or [])]
+                source_refs: list[dict] = []
+                index_ids: list[str] = []
+                for article_id in source_ids:
+                    map_key = f"{digest_file}::{article_id}"
+                    mapped = map_rows.get(map_key)
+                    if not mapped:
+                        continue
+                    index_id = str(mapped.get("index_id") or "").strip()
+                    if not index_id:
+                        continue
+                    index_ids.append(index_id)
+                    source_refs.append(
+                        {
+                            "index_id": index_id,
+                            "article_id": article_id,
+                            "title": str(mapped.get("Title") or "").strip(),
+                            "source": str(mapped.get("Source") or "").strip(),
+                            "url": str(mapped.get("Link") or "").strip(),
+                        }
+                    )
+
+                brief_id = _brief_id(digest_id, digest_group_id, idea, ordinal)
+                piece_brief = {
+                    "schema_name": "news_piece_brief.v1",
+                    "brief_id": brief_id,
+                    "digest_id_hour": digest_id,
+                    "digest_group_id": digest_group_id,
+                    "digest_file": digest_file,
+                    "topic": str(idea.get("topic") or topic_str or "All Topics").strip(),
+                    "working_title": str(idea.get("working_title") or idea.get("idea_title") or "").strip(),
+                    "angle": str(idea.get("angle") or idea.get("draft_editorial_angle") or "").strip(),
+                    "key_facts": [str(x).strip() for x in (idea.get("key_facts") or []) if str(x).strip()],
+                    "potential_controversies": [
+                        str(x).strip() for x in (idea.get("potential_controversies") or []) if str(x).strip()
+                    ],
+                    "relevant_quotes": [str(x).strip() for x in (idea.get("relevant_quotes") or []) if str(x).strip()],
+                    "source_index_ids": index_ids,
+                    "source_refs": source_refs,
+                    "meta": {
+                        "idea_id": str(idea.get("idea_id") or "").strip(),
+                        "group_no": group_no,
+                    },
+                }
+
+                if not piece_brief["working_title"]:
+                    bio.append_jsonl(quarantine_path("V06", run_id), {"reason": "missing_working_title", "brief_id": brief_id})
+                    bad_briefs += 1
+                    continue
+
+                if not dry_run:
+                    out_path = BRIEFS_DIR / f"{brief_id}.jsonl"
+                    atomic_write_one_jsonl(out_path, piece_brief)
+                ok_briefs += 1
+
+    try:
+        db.finish_run(run_id, ok=ok_briefs, fail=bad_briefs)
+    except Exception:
+        pass
+
+    print(f"[{stage_name}] digest_id={digest_id} briefs_ok={ok_briefs} bad={bad_briefs} -> {BRIEFS_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/legacy/stage06_build_piece_briefs.py
+++ b/legacy/stage06_build_piece_briefs.py
@@ -1,0 +1,10 @@
+"""Legacy compatibility wrapper for editorial stage06.
+
+Primary implementation moved to apps.news_editorial.src.news_editorial.stage06_build_piece_briefs.
+"""
+
+from apps.news_editorial.src.news_editorial.stage06_build_piece_briefs import run
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ define _env_prefix
 DIGEST_AT=$(DIGEST_AT) DRY_RUN=$(DRY_RUN) LIMIT=$(LIMIT) SAMPLE=$(SAMPLE) NULL_SINK=$(NULL_SINK)
 endef
 
-.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a build-news-access-indexes heartbeat-start heartbeat-stop heartbeat-status
+.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 s06 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a build-news-access-indexes heartbeat-start heartbeat-stop heartbeat-status
 
 help:      ## Show help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' Makefile | sed 's/:.*## / — /' | sort
@@ -139,6 +139,9 @@ pf-article: ## Force PF over per-article pfin file
 s05:       ## Stage 05 — explode PF outputs → drafts + enqueue generate
 	@$(_env_prefix) $(PYTHON) -m legacy.stage05_explode_pf_outputs
 
+s06:       ## Stage 06 — build news_piece_brief.v1 seam from PF seed_ideas
+	@$(_env_prefix) $(PYTHON) -m legacy.stage06_build_piece_briefs
+
 export-pr3a: ## PR3a real exports: legacy outputs -> storage buses/indexes
 	@$(PYTHON) scripts/export_pr3a_buses.py --digest-at $(DIGEST_AT)
 
@@ -156,19 +159,20 @@ pf:        ## Run PromptFlow once for the hour (direct CLI)
 explode:   ## Join+validate drafts for the hour
 	@$(MAKE) s05
 
-all:       ## 01 → 02 → 03 → 04 → 05 (respecting DRY_RUN/NULL_SINK)
-	@$(MAKE) s01 && $(MAKE) s02 && $(MAKE) s03 && $(MAKE) s04 && $(MAKE) s05
+all:       ## 01 → 02 → 03 → 04 → 06 → 05 (respecting DRY_RUN/NULL_SINK)
+	@$(MAKE) s01 && $(MAKE) s02 && $(MAKE) s03 && $(MAKE) s04 && $(MAKE) s06 && $(MAKE) s05
 
 # ------------ Run any stage by number ------------
 stage-any: ## Run any stage by number: make stage-any STAGE=03
-	@if [ -z "$(STAGE)" ]; then echo "STAGE is required (01..05)"; exit 2; fi; \
+	@if [ -z "$(STAGE)" ]; then echo "STAGE is required (01..06)"; exit 2; fi; \
 	case "$(STAGE)" in \
 	  01) MOD=legacy.stage01_digests ;; \
 	  02) MOD=legacy.stage02_master_index_update ;; \
 	  03) MOD=legacy.stage03_headlines_digests ;; \
 	  04) echo "Use: make s04 (PF CLI)"; exit 2 ;; \
 	  05) MOD=legacy.stage05_explode_pf_outputs ;; \
-	  *)  echo "Unknown STAGE=$(STAGE) (expected 01..05)"; exit 2 ;; \
+	  06) MOD=legacy.stage06_build_piece_briefs ;; \
+	  *)  echo "Unknown STAGE=$(STAGE) (expected 01..06)"; exit 2 ;; \
 	esac; \
 	echo ">> Running $$MOD with DIGEST_AT=$(DIGEST_AT)"; \
 	$(_env_prefix) $(PYTHON) -m $$MOD

--- a/tests/test_news_editorial_briefs_pipeline.py
+++ b/tests/test_news_editorial_briefs_pipeline.py
@@ -1,0 +1,70 @@
+import sys
+import types
+
+sys.modules.setdefault("psycopg", types.SimpleNamespace(connect=lambda *args, **kwargs: None))
+
+from apps.news_editorial.src.news_editorial import stage05_explode_pf_outputs as stage05
+from apps.news_editorial.src.news_editorial import stage06_build_piece_briefs as stage06
+
+
+def test_stage06_extract_seed_ideas_normalizes_legacy_key() -> None:
+    row = {
+        "seed_ideas": {
+            "seed_ideas": [
+                {
+                    "idea_id": "A1",
+                    "idea_title": "Título",
+                    "key_data_points": ["dato legacy"],
+                }
+            ]
+        }
+    }
+
+    ideas = stage06.extract_seed_ideas(row)
+
+    assert len(ideas) == 1
+    assert ideas[0]["key_facts"] == ["dato legacy"]
+
+
+def test_stage05_builds_draft_from_brief_as_canonical_input() -> None:
+    brief = {
+        "schema_name": "news_piece_brief.v1",
+        "brief_id": "npb_123",
+        "digest_id_hour": "20260101T01",
+        "digest_file": "hour_20260101T0100",
+        "topic": "Economía",
+        "working_title": "Titular desde brief",
+        "angle": "Ángulo desde brief",
+        "source_index_ids": ["IDX001"],
+    }
+    mapped_by_index = {
+        "IDX001": {
+            "index_id": "IDX001",
+            "article_id": "10",
+            "digest_file": "hour_20260101T0100",
+            "Title": "Título mapeado",
+            "Source": "Fuente",
+            "Link": "https://example.com/a",
+            "Published": "2026-01-01T01:00:00Z",
+            "Topic": "Economía",
+        }
+    }
+
+    draft, err = stage05.make_draft_obj_from_brief(brief, mapped_by_index)
+
+    assert err is None
+    assert draft is not None
+    assert draft["headline"] == "Titular desde brief"
+    assert draft["dek"] == "Ángulo desde brief"
+    assert draft["cluster_id"] == "npb_123"
+    assert draft["meta"]["brief_schema"] == "news_piece_brief.v1"
+    assert draft["citations"][0]["url"] == "https://example.com/a"
+
+
+def test_stage06_brief_id_is_stable_by_digest_group_and_idea() -> None:
+    idea = {"idea_id": "EC01"}
+    one = stage06._brief_id("20260101T01", "20260101T01::hour::eco::01", idea, 1)
+    two = stage06._brief_id("20260101T01", "20260101T01::hour::eco::01", idea, 99)
+
+    assert one == two
+    assert one.startswith("npb_")


### PR DESCRIPTION
### Motivation
- Introduce a canonical brief seam so editorial `seed_ideas` can be materialized as durable, idempotent briefs consumed by packaging/packaging logic.
- Ensure packaging (`stage05`) prefers persisted `news_piece_brief.v1` as the canonical input for creating drafts, while preserving runtime compatibility with the existing cluster-based path.
- Provide an explicit transitional signal when briefs are missing so operators can observe and migrate safely.

### Description
- Added `apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py` to read PF `seed_ideas`, normalize legacy keys (`key_data_points` → `key_facts`), construct `news_piece_brief.v1` payloads, and persist them idempotently to `storage/buses/news_piece_brief/v1/<brief_id>.jsonl` (one-record JSONL files keyed by `brief_id`).
- Refactored `apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py` so it first loads `news_piece_brief.v1` briefs for the hour and packages drafts from briefs via `make_draft_obj_from_brief`; retained cluster-based packaging as a fallback path.
- When no briefs are found `stage05` emits an explicit warning and writes a quarantine entry with reason `missing_piece_briefs_fallback_legacy` before falling back to the legacy cluster flow.
- Added orchestration and compatibility: `make s06`, `all` now runs `s04 -> s06 -> s05`, `stage-any` supports `06`, a legacy wrapper `legacy/stage06_build_piece_briefs.py`, updated owner wrapper to run `s04 -> s06 -> s05`, and updated `apps/news_editorial/README.md`.
- Added unit tests `tests/test_news_editorial_briefs_pipeline.py` covering seed-idea normalization, stable brief id generation, and draft construction from briefs.

### Testing
- Ran `pytest -q tests/test_news_editorial_briefs_pipeline.py tests/test_pf_seed_ideas_contract.py` and all tests passed (`5 passed`).
- Ran `python -m compileall apps/news_editorial/src/news_editorial legacy tests/test_news_editorial_briefs_pipeline.py` and byte-compilation succeeded.
- Light runtime checks performed: new `make` targets and owner wrapper updated to include `s06`, and pipeline preserves legacy fallback behavior when briefs are absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b598ee7a5c832daeb20300ccb9a6cb)