### PR TITLE
Add publish surface canonical contract and validation target

### DIFF
--- a/contracts/schemas/publish_surface_v1.json
+++ b/contracts/schemas/publish_surface_v1.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://media-monitor/contracts/publish_surface_v1.json",
+  "title": "publish_surface_v1",
+  "description": "Canonical publishing surface contract. This schema is the source of truth for adapters and UI projections.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "schema_name": {
+      "const": "publish_surface_v1"
+    },
+    "frontpage_items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/FrontpageItem"
+      },
+      "default": []
+    },
+    "stories": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Story"
+      },
+      "default": []
+    },
+    "topic_pages": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/TopicPage"
+      },
+      "default": []
+    },
+    "editorial_handoff_items": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/EditorialHandoffItem"
+      },
+      "default": []
+    }
+  },
+  "required": [
+    "schema_name",
+    "frontpage_items",
+    "stories",
+    "topic_pages",
+    "editorial_handoff_items"
+  ],
+  "$defs": {
+    "FrontpageItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Primary UI tile used in recency frontpage lists.",
+      "properties": {
+        "digest_at": {
+          "type": "string",
+          "description": "Hour bucket. Required. Fallback: 'unknown'."
+        },
+        "title": {
+          "type": "string",
+          "description": "Required display title. Fallback: '(untitled)'."
+        },
+        "topic": {
+          "type": "string",
+          "description": "Required taxonomy label. Fallback: 'unknown'."
+        },
+        "published_at": {
+          "type": "string",
+          "description": "Required RFC3339 timestamp. Fallback: '1970-01-01T00:00:00Z'."
+        },
+        "link": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required canonical URL. No fallback; invalid when absent."
+        },
+        "source": {
+          "type": "string",
+          "description": "Optional source label. Fallback: 'unknown'."
+        },
+        "index_id": {
+          "type": "string",
+          "description": "Optional internal id used by adapters for back-links. Fallback: ''."
+        }
+      },
+      "required": [
+        "digest_at",
+        "title",
+        "topic",
+        "published_at",
+        "link"
+      ]
+    },
+    "Story": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Canonical story identity projected from refs and consumed by adapters/UI details routes.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Required stable id. Fallback: index_id, then link hash at adapter layer."
+        },
+        "title": {
+          "type": "string",
+          "description": "Required human title. Fallback: '(untitled)'."
+        },
+        "topic": {
+          "type": "string",
+          "description": "Required routing topic. Fallback: 'unknown'."
+        },
+        "source": {
+          "type": "string",
+          "description": "Optional publisher/source. Fallback: 'unknown'."
+        },
+        "published_at": {
+          "type": "string",
+          "description": "Optional timestamp. Fallback: '1970-01-01T00:00:00Z'."
+        },
+        "link": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Required canonical URL. No fallback."
+        }
+      },
+      "required": [
+        "id",
+        "title",
+        "topic",
+        "link"
+      ]
+    },
+    "TopicPage": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Topic landing page metadata and ranking payload.",
+      "properties": {
+        "digest_at": {
+          "type": "string",
+          "description": "Required hour bucket. Fallback: 'unknown'."
+        },
+        "topic": {
+          "type": "string",
+          "description": "Required topic slug/label. Fallback: 'unknown'."
+        },
+        "window_type": {
+          "type": "string",
+          "description": "Required digest window classifier. Fallback: 'unknown'."
+        },
+        "group_number": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional grouping index. Fallback: 0."
+        },
+        "article_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional aggregate volume. Fallback: 0."
+        },
+        "top_titles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional preview list. Fallback: []."
+        }
+      },
+      "required": [
+        "digest_at",
+        "topic",
+        "window_type"
+      ]
+    },
+    "EditorialHandoffItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Editor-facing recommendation generated from human_handoff.action_candidates.",
+      "properties": {
+        "target_format": {
+          "type": "string",
+          "enum": [
+            "article",
+            "yt_script"
+          ],
+          "description": "Required delivery format. Fallback: 'article'."
+        },
+        "ready_state": {
+          "type": "string",
+          "description": "Required readiness marker. Fallback: 'unknown'."
+        },
+        "title": {
+          "type": "string",
+          "description": "Required display label. Fallback: topic, then '(untitled)'."
+        },
+        "topic": {
+          "type": "string",
+          "description": "Required editorial topic. Fallback: 'unknown'."
+        },
+        "priority": {
+          "type": "string",
+          "description": "Optional prioritization hint. Fallback: 'normal'."
+        },
+        "source": {
+          "type": "string",
+          "description": "Optional origin lane. Fallback: 'unknown'."
+        },
+        "path": {
+          "type": "string",
+          "description": "Optional file pointer. Fallback: ''."
+        }
+      },
+      "required": [
+        "target_format",
+        "ready_state",
+        "title",
+        "topic"
+      ]
+    }
+  }
+}

--- a/docs/runbooks/pr9-newspaper-skin-implementation-prs.md
+++ b/docs/runbooks/pr9-newspaper-skin-implementation-prs.md
@@ -1,0 +1,71 @@
+# PR9 — Newspaper skin implementation PRs
+
+## Contract authority
+
+`contracts/schemas/publish_surface_v1.json` es la autoridad del contrato de publicación.
+
+- Adapters deben mapear datos internos a este schema y **no** introducir campos obligatorios fuera del contrato.
+- UI debe consumir este shape canónico y tratar sus valores fallback como comportamiento esperado, no como errores de parsing.
+- Si hay conflicto entre shape actual de índices y la UI, manda este schema; primero se corrige adapter/proyección.
+
+## Canonical objects
+
+### `FrontpageItem`
+
+- **Obligatorios:** `digest_at`, `title`, `topic`, `published_at`, `link`.
+- **Opcionales:** `source`, `index_id`.
+- **Fallback behavior:**
+  - `digest_at` -> `"unknown"`
+  - `title` -> `"(untitled)"`
+  - `topic` -> `"unknown"`
+  - `published_at` -> `"1970-01-01T00:00:00Z"`
+  - `source` -> `"unknown"`
+  - `index_id` -> `""`
+  - `link` no tiene fallback (si falta, falla validación).
+
+### `Story`
+
+- **Obligatorios:** `id`, `title`, `topic`, `link`.
+- **Opcionales:** `source`, `published_at`.
+- **Fallback behavior:**
+  - `id` -> usar `index_id`; si falta, resolver en adapter con hash de `link`.
+  - `title` -> `"(untitled)"`
+  - `topic` -> `"unknown"`
+  - `source` -> `"unknown"`
+  - `published_at` -> `"1970-01-01T00:00:00Z"`
+  - `link` no tiene fallback.
+
+### `TopicPage`
+
+- **Obligatorios:** `digest_at`, `topic`, `window_type`.
+- **Opcionales:** `group_number`, `article_count`, `top_titles`.
+- **Fallback behavior:**
+  - `digest_at` -> `"unknown"`
+  - `topic` -> `"unknown"`
+  - `window_type` -> `"unknown"`
+  - `group_number` -> `0`
+  - `article_count` -> `0`
+  - `top_titles` -> `[]`
+
+### `EditorialHandoffItem`
+
+- **Obligatorios:** `target_format`, `ready_state`, `title`, `topic`.
+- **Opcionales:** `priority`, `source`, `path`.
+- **Fallback behavior:**
+  - `target_format` -> `"article"`
+  - `ready_state` -> `"unknown"`
+  - `title` -> `topic` o `"(untitled)"`
+  - `topic` -> `"unknown"`
+  - `priority` -> `"normal"`
+  - `source` -> `"unknown"`
+  - `path` -> `""`
+
+## Validation gate
+
+El check operativo es `make validate-publish-surface`, que corre `scripts/validate_publish_surface.py` sobre:
+
+- `storage/indexes/news_recent_refs_latest.jsonl`
+- `storage/indexes/news_recent_groups_latest.jsonl`
+- `storage/indexes/editorial_latest.json`
+
+El comando debe fallar (exit code != 0) cuando falten archivos o el shape no cumpla contrato.

--- a/makefile
+++ b/makefile
@@ -24,7 +24,7 @@ define _env_prefix
 DIGEST_AT=$(DIGEST_AT) DRY_RUN=$(DRY_RUN) LIMIT=$(LIMIT) SAMPLE=$(SAMPLE) NULL_SINK=$(NULL_SINK)
 endef
 
-.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 s06 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a build-news-access-indexes build-editorial-access-indexes heartbeat-start heartbeat-stop heartbeat-status
+.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 s06 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a build-news-access-indexes build-editorial-access-indexes validate-publish-surface heartbeat-start heartbeat-stop heartbeat-status
 
 help:      ## Show help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' Makefile | sed 's/:.*## / — /' | sort
@@ -150,6 +150,9 @@ build-news-access-indexes: ## Build compact readable latest-news access indexes 
 
 build-editorial-access-indexes: ## Build compact editorial status index (seed/brief/draft/fallback)
 	@$(PYTHON) scripts/build_editorial_access_indexes.py --digest-at $(DIGEST_AT)
+
+validate-publish-surface: ## Validate canonical publish surface contract from latest indexes
+	@$(PYTHON) scripts/validate_publish_surface.py --storage-dir storage
 
 # ------------ Pipelines ------------
 prep:      ## 01+02 on fixed hour (safe defaults DRY_RUN=1)

--- a/scripts/validate_publish_surface.py
+++ b/scripts/validate_publish_surface.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{lineno}: invalid json: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{lineno}: expected object, got {type(row).__name__}")
+            rows.append(row)
+    return rows
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{path}: invalid json: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected object root, got {type(payload).__name__}")
+    return payload
+
+
+def _require_string(obj: dict[str, Any], key: str, *, min_length: int = 0) -> str:
+    value = obj.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"missing/invalid '{key}' (expected string)")
+    if len(value.strip()) < min_length:
+        raise ValueError(f"invalid '{key}' (min_length={min_length})")
+    return value
+
+
+def _require_int(obj: dict[str, Any], key: str, *, minimum: int = 0) -> int:
+    value = obj.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"missing/invalid '{key}' (expected int)")
+    if value < minimum:
+        raise ValueError(f"invalid '{key}' (minimum={minimum})")
+    return value
+
+
+def _validate_frontpage_item(row: dict[str, Any], idx: int) -> None:
+    _require_string(row, "digest_at", min_length=1)
+    _require_string(row, "title", min_length=1)
+    _require_string(row, "topic", min_length=1)
+    _require_string(row, "published_at", min_length=1)
+    _require_string(row, "link", min_length=1)
+
+    source = row.get("source")
+    if source is not None and not isinstance(source, str):
+        raise ValueError(f"row#{idx}: invalid 'source' (expected string)")
+    index_id = row.get("index_id")
+    if index_id is not None and not isinstance(index_id, str):
+        raise ValueError(f"row#{idx}: invalid 'index_id' (expected string)")
+
+
+def _validate_story(row: dict[str, Any], idx: int) -> None:
+    story_id = row.get("index_id") or row.get("link")
+    if not isinstance(story_id, str) or not story_id.strip():
+        raise ValueError(f"row#{idx}: cannot resolve Story.id from index_id/link")
+    _require_string(row, "title", min_length=1)
+    _require_string(row, "topic", min_length=1)
+    _require_string(row, "link", min_length=1)
+
+
+def _validate_topic_page(row: dict[str, Any], idx: int) -> None:
+    _require_string(row, "digest_at", min_length=1)
+    _require_string(row, "topic", min_length=1)
+    _require_string(row, "window_type", min_length=1)
+
+    _require_int(row, "group_number", minimum=0)
+    _require_int(row, "article_count", minimum=0)
+
+    top_titles = row.get("top_titles")
+    if not isinstance(top_titles, list):
+        raise ValueError(f"row#{idx}: invalid 'top_titles' (expected list)")
+    if any(not isinstance(v, str) for v in top_titles):
+        raise ValueError(f"row#{idx}: invalid 'top_titles' (all entries must be string)")
+
+
+def _validate_editorial_handoff_item(row: dict[str, Any], idx: int) -> None:
+    target_format = _require_string(row, "target_format", min_length=1)
+    if target_format not in {"article", "yt_script"}:
+        raise ValueError(f"item#{idx}: invalid 'target_format' ({target_format!r})")
+
+    _require_string(row, "ready_state", min_length=1)
+    _require_string(row, "title", min_length=1)
+    _require_string(row, "topic", min_length=1)
+
+    for optional in ("priority", "source", "path"):
+        value = row.get(optional)
+        if value is not None and not isinstance(value, str):
+            raise ValueError(f"item#{idx}: invalid '{optional}' (expected string)")
+
+
+def validate_publish_surface(storage_dir: Path) -> None:
+    refs_path = storage_dir / "indexes" / "news_recent_refs_latest.jsonl"
+    groups_path = storage_dir / "indexes" / "news_recent_groups_latest.jsonl"
+    editorial_path = storage_dir / "indexes" / "editorial_latest.json"
+
+    for path in (refs_path, groups_path, editorial_path):
+        if not path.exists():
+            raise ValueError(f"missing required file: {path}")
+
+    refs = _iter_jsonl(refs_path)
+    groups = _iter_jsonl(groups_path)
+    editorial = _read_json(editorial_path)
+
+    for idx, row in enumerate(refs, start=1):
+        try:
+            _validate_frontpage_item(row, idx)
+            _validate_story(row, idx)
+        except ValueError as exc:
+            raise ValueError(f"{refs_path}: row#{idx}: {exc}") from exc
+
+    for idx, row in enumerate(groups, start=1):
+        try:
+            _validate_topic_page(row, idx)
+        except ValueError as exc:
+            raise ValueError(f"{groups_path}: row#{idx}: {exc}") from exc
+
+    human_handoff = editorial.get("human_handoff")
+    if not isinstance(human_handoff, dict):
+        raise ValueError(f"{editorial_path}: missing/invalid 'human_handoff' object")
+
+    action_candidates = human_handoff.get("action_candidates")
+    if not isinstance(action_candidates, list):
+        raise ValueError(f"{editorial_path}: missing/invalid 'human_handoff.action_candidates' list")
+
+    for idx, item in enumerate(action_candidates, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"{editorial_path}: item#{idx}: expected object")
+        try:
+            _validate_editorial_handoff_item(item, idx)
+        except ValueError as exc:
+            raise ValueError(f"{editorial_path}: {exc}") from exc
+
+    print(f"[validate-publish-surface] frontpage_items={len(refs)}")
+    print(f"[validate-publish-surface] stories={len(refs)}")
+    print(f"[validate-publish-surface] topic_pages={len(groups)}")
+    print(f"[validate-publish-surface] editorial_handoff_items={len(action_candidates)}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate publish surface canonical contract against latest indexes")
+    parser.add_argument("--storage-dir", default="storage", help="Storage root containing indexes/")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        validate_publish_surface(Path(args.storage_dir))
+    except ValueError as exc:
+        print(f"[validate-publish-surface] ERROR: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a single canonical publish-surface contract that adapters and UI must follow so projections are consistent and fallback behavior is explicit.
- Add an automated validation gate to detect mismatches early between runtime indexes and the publish surface expected by adapters/UI.

### Description

- Added `contracts/schemas/publish_surface_v1.json` defining canonical objects `FrontpageItem`, `Story`, `TopicPage`, and `EditorialHandoffItem` with required/optional fields and documented fallback behavior.
- Added runbook `docs/runbooks/pr9-newspaper-skin-implementation-prs.md` with a “Contract authority” section, per-object required/optional fields and fallback rules, and instructions for the validation gate.
- Implemented validator `scripts/validate_publish_surface.py` that loads and validates records from `storage/indexes/news_recent_refs_latest.jsonl`, `storage/indexes/news_recent_groups_latest.jsonl`, and `storage/indexes/editorial_latest.json` and exits non-zero on missing files or shape/type errors.
- Added Makefile target `validate-publish-surface` that runs the validator (`scripts/validate_publish_surface.py --storage-dir storage`).

### Testing

- Ran `make build-news-access-indexes build-editorial-access-indexes validate-publish-surface` which executed the access/index builders and the new validator and completed successfully (printed counts and returned exit 0).
- Verified validator prints counts: frontpage_items, stories, topic_pages and editorial_handoff_items and that it fails (non-zero exit) when required files are missing or records are malformed (behavior implemented and exercised).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c6e2eac8832d925a0afd9bccd33d)