### PR TITLE
Add newspaper-skin guide and PR9 runbook for Next.js + Contentlayer implementation

### DIFF
--- a/codex_newspaper_skin_guide.md
+++ b/codex_newspaper_skin_guide.md
@@ -1,0 +1,224 @@
+# Guía para Codex: sprint "newspaper skin" sobre `next-contentlayer`
+
+## Contexto
+
+Construir la capa pública del medio con **Next.js + Contentlayer + Tailwind**, usando `shadcn/next-contentlayer` como base técnica, y `web3templates/stablo` solo como referencia visual. El contenido debe venir del pipeline existente, no de un CMS nuevo.
+
+**Ruta canónica:**
+
+`news in -> brief -> draft -> human last mile -> published site`
+
+## Restricciones duras
+
+1. **No CMS nuevo**: no Sanity, no Wisp, no DB editorial paralela.
+2. **No mover source of truth**: la web consume artefactos compactos del sistema actual.
+3. **No big refactor** de acquire/editorial/enrich.
+4. **No wrappers ornamentales**: cada capa nueva debe reducir ambigüedad real.
+5. **Repos externos permitidos con control**: solo para extraer patrones/layout o copiar componentes puntuales.
+
+## Repos externos permitidos
+
+### Base técnica preferida
+
+- `shadcn/next-contentlayer`
+
+### Referencia estética opcional
+
+- `web3templates/stablo` (solo layout/componentes; no Sanity)
+
+### Referencia secundaria
+
+- Templates de Vercel (patrones, no gobernanza)
+
+
+## Comparación práctica con `shadcn/next-contentlayer`
+
+`shadcn/next-contentlayer` encaja como base técnica de shell (App Router + Tailwind + estructura limpia), pero su flujo por defecto usa MDX/Contentlayer como fuente principal de posts. En este repo eso **no** debe gobernar la salida editorial pública.
+
+Regla operativa:
+
+- **Sí**: reutilizar estructura de app, layout, estilos y componentes de presentación.
+- **No**: usar `content/posts` + `allPosts` como verdad editorial del outlet.
+- **Sí condicional**: Contentlayer solo para páginas estáticas auxiliares (about/help), nunca para feed/handoff.
+
+
+## Entregables que debe producir Codex
+
+### 1) Arquitectura mínima del sitio
+
+Propuesta tipo:
+
+- `apps/news_site/` (o equivalente claro)
+- `app/`
+- `components/`
+- `lib/`
+- `public/`
+- `scripts/` (si hace falta compactar snapshots)
+
+> El contenido editorial dinámico no se define en MDX manual como fuente primaria.
+
+### 2) Adapter seam explícito
+
+Definir y documentar consumo de artefactos, por ejemplo:
+
+- `storage/indexes/news_recent_refs_latest.jsonl`
+- `storage/indexes/news_recent_groups_latest.jsonl`
+- `storage/indexes/editorial_latest.json`
+- snapshots de drafts listos para publish
+
+Si hay transformación intermedia, debe ser mínima, local y con contrato claro.
+
+### 3) Newspaper skin
+
+Prioridades de UI:
+
+- portada con hero
+- rail de últimas noticias
+- bloques por topic/category
+- artículo individual
+- listado por tema
+- navegación sobria y grilla editorial densa
+- espacio para `analysis`, `latest`, `video`, `opinion` (aunque algunos sean placeholders iniciales)
+
+### 4) Plan de pruning
+
+Inventario explícito de qué parte del template:
+
+- se usa
+- se omite
+- se archiva
+- se elimina
+
+Evitar “template bloat”.
+
+## Preguntas obligatorias antes de tocar código
+
+1. ¿Cuál es el source of truth exacto para la capa pública?
+2. ¿Qué archivos actuales alcanzan para una portada útil hoy?
+3. ¿Falta dato, mapping o skin?
+4. ¿Qué partes del template externo son reutilizables sin arrastrar CMS?
+5. ¿Cuál es la ruta más corta a una portada viva?
+
+## Criterios de decisión
+
+Cada cambio debe responder **sí** a todo esto:
+
+- ¿Reduce ambigüedad en la ruta canónica?
+- ¿Acerca a “human last mile sobre generated drafts”?
+- ¿Mantiene contracts como autoridad?
+- ¿Evita segunda gobernanza editorial?
+- ¿Facilita publicar hoy?
+
+## Tareas permitidas
+
+### Sí
+
+- inspeccionar/clone de `shadcn/next-contentlayer` y `stablo`
+- copiar componentes UI selectivos
+- construir app Next.js mínima
+- conectar lectores de índices compactos
+- usar fixtures/mocks temporales claramente marcados
+- documentar qué se importó y qué se descartó
+
+### No
+
+- introducir Sanity o CMS alterno
+- mover source of truth al frontend
+- importar ecosistema completo sin pruning
+- rediseñar backend pipeline
+
+## Orden sugerido del sprint
+
+### PR-1 — Bootstrap sitio público mínimo
+
+- app Next.js local
+- layout base
+- home simple
+- consumo de `news_recent_refs_latest.jsonl` y `news_recent_groups_latest.jsonl`
+
+### PR-2 — Newspaper skin
+
+- hero, latest rail, topic blocks
+- shell de artículo y categoría
+- tipografía + spacing editorial
+
+### PR-3 — Editorial handoff surface
+
+- lectura de `editorial_latest.json`
+- vista de briefs/drafts listos
+- prioridad YT-first si existe señal
+
+### PR-4 — Pruning + canonización
+
+- limpieza de template bloat
+- README operativo corto
+- truth table: source-of-truth / adapter / UI / historical
+
+## Forma de entrega esperada por PR
+
+- objetivo
+- por qué importa ahora
+- scope exacto
+- non-goals
+- done criteria
+- riesgos
+- evidencia runtime/screenshots
+- lista de archivos importados de repos externos
+- componentes usados vs descartados
+
+## Prompt corto para pegar en Codex
+
+```text
+Context:
+We are building a semi-automated editorial outlet. The canonical architecture is contracts-first and runtime-first. The public site must consume compacted outputs from the existing system, not create a new source of truth.
+
+Primary technical base:
+- shadcn/next-contentlayer as preferred frontend shell
+Secondary visual reference:
+- web3templates/stablo for layout inspiration only
+Do not adopt Sanity or any new CMS.
+
+North:
+news in -> brief -> draft -> human last mile -> published site
+
+Hard constraints:
+- no new CMS
+- no new editorial DB
+- no changing source of truth
+- no big refactor of acquire/editorial/enrich
+- no fluffy wrappers
+- keep compatibility with KB contracts mindset
+
+You are allowed to inspect external repos/templates, but only to:
+- extract layout/page patterns
+- copy selected UI components
+- compare structure
+- derive a minimal local implementation
+
+Do:
+1. Propose the smallest viable public site architecture.
+2. Identify the exact current files/indexes to consume.
+3. Build a minimal newspaper-style frontend surface.
+4. Keep the adapter seam explicit between indexes/contracts and UI.
+5. Prefer a clean golden path over flexibility.
+
+Do not:
+- introduce Sanity, Wisp, or another CMS
+- move source of truth into the frontend
+- import whole template ecosystems without pruning
+- redesign the backend pipeline
+
+Output format:
+- Reassessment
+- Proposed PRs (max 4)
+- For each PR: goal, why now, scope, non-goals, done criteria, risks
+- Explicit note on which external repo files/components you would reuse
+```
+
+## Ejecución inmediata en este repo
+
+Para pasar de guía a ejecución, seguir `docs/runbooks/pr9-newspaper-skin-implementation-prs.md`, que traduce esta guía a PRs concretos con scope, non-goals, checks y done criteria.
+
+## Cierre
+
+Usar templates como material, no como autoridad arquitectónica.

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -9,6 +9,7 @@ Guía rápida para distinguir qué documento usar según objetivo.
 
 ## Consolidation and pruning
 
+- `pr9-newspaper-skin-implementation-prs.md` — PRs concretos para construir la capa pública tipo news outlet (site + ops + read API).
 - `pr5-pruning-diagnostic-and-phased-plan.md` — pruning guiado por runtime con guardrails.
 - `pr5-observability-indexes-prep.md` — preparación de índices de observabilidad compacta.
 - `pr6-wrapper-surface-inventory.md` — inventario de wrappers/helpers y shortlist canónica de comandos operativos.

--- a/docs/runbooks/pr9-newspaper-skin-implementation-prs.md
+++ b/docs/runbooks/pr9-newspaper-skin-implementation-prs.md
@@ -1,0 +1,292 @@
+# PR9 — Newspaper skin: PRs reales a ejecutar
+
+Este runbook convierte la guía estratégica en una secuencia de PRs **ejecutables hoy** para llegar a una superficie pública viva sin romper la ruta canónica:
+
+`news in -> brief -> draft -> human last mile -> published site`
+
+## Objetivo operativo
+
+Publicar una primera versión de sitio tipo “news outlet” que:
+
+1. Lea artefactos compactos existentes.
+2. Mantenga `media_monitor` como source-of-truth editorial.
+3. Sea desplegable de forma incremental (PRs pequeños, reversibles, con evidencia runtime).
+
+---
+
+## Supuestos y seam canónico
+
+### Source-of-truth
+
+- Pipeline y buses/indexes en este repo.
+- No CMS nuevo.
+- No DB editorial nueva para gobernanza.
+
+### Seams mínimos a consumir (ya existentes)
+
+- `storage/indexes/news_recent_refs_latest.jsonl`
+- `storage/indexes/news_recent_groups_latest.jsonl`
+- `storage/indexes/editorial_latest.json`
+
+> Si alguna corrida no produjo uno de estos artefactos, el PR correspondiente debe incluir fallback explícito (`empty state`) y un check de precondición en scripts.
+
+---
+
+## PR-1 — Bootstrap de `apps/news_site` con adapter local
+
+### Goal
+
+Crear una app Next.js mínima (App Router) que renderice portada desde snapshots locales sin inventar modelo editorial nuevo.
+
+### Why now
+
+Sin bootstrap real no hay superficie para validar skin, slugs ni loop de publicación.
+
+### Scope
+
+- Crear `apps/news_site/` con estructura mínima:
+  - `app/layout.tsx`
+  - `app/page.tsx`
+  - `app/(site)/tema/[slug]/page.tsx` (shell)
+  - `app/(ops)/ops/page.tsx` (placeholder privado)
+  - `components/` (cards/listas básicas)
+  - `lib/adapter/` (lectura + mapping de índices compactos)
+- Implementar adapter **read-only** que mapee los índices compactos a view models (`FrontpageItem`, `TopicBlock`, etc.).
+- Agregar `README` operativo en `apps/news_site/README.md` con comandos `dev` y precondiciones de datos.
+
+### Non-goals
+
+- Sin Sanity.
+- Sin autenticación completa.
+- Sin API nueva todavía.
+
+### Done criteria
+
+- `npm run dev` en `apps/news_site` levanta portada funcional.
+- La portada muestra al menos 10 ítems desde `news_recent_refs_latest.jsonl`.
+- Si faltan índices, se muestra `empty state` claro (sin crash).
+
+### Riesgos
+
+- Variabilidad de shape en JSONL/JSON.
+- Slugs inconsistentes en topic labels.
+
+### Checks sugeridos
+
+- `node -e "JSON.parse(require('fs').readFileSync('../../storage/indexes/editorial_latest.json','utf8'))"`
+- Script de validación de índices previo a `next dev`.
+
+---
+
+## PR-2 — Newspaper skin (público)
+
+### Goal
+
+Pasar de “demo blog” a layout editorial (hero, latest rail, topic blocks, article shell).
+
+### Why now
+
+Con datos reales ya conectados, la mejora visual desbloquea review de producto y lectura humana.
+
+### Scope
+
+- `app/page.tsx`: hero + latest rail + bloques por topic.
+- `app/(site)/tema/[slug]/page.tsx`: listado por tema.
+- `app/(site)/articulo/[id]/page.tsx`: artículo shell usando view model derivado.
+- Componentes de UI selectivos inspirados en templates externos (copiados de forma puntual, con pruning documentado).
+
+### Non-goals
+
+- No migrar tema completo de Stablo.
+- No meter librerías de CMS.
+
+### Done criteria
+
+- Navegación portada -> tema -> artículo funcionando.
+- Densidad visual tipo medio (no blog personal).
+- Lista explícita en PR de componentes reutilizados vs descartados.
+
+### Riesgos
+
+- Sobre-importar componentes muertos.
+- Regressions en responsive.
+
+### Checks sugeridos
+
+- `npm run build` en `apps/news_site`.
+- Capturas de `/`, `/tema/<slug>`, `/articulo/<id>`.
+
+---
+
+## PR-3 — Superficie editorial/ops
+
+### Goal
+
+Agregar vista interna para handoff editorial con foco en “última milla humana”.
+
+### Why now
+
+Es la capa que convierte drafts automáticos en publicación controlada.
+
+### Scope
+
+- `app/(ops)/ops/page.tsx` con lectura de `editorial_latest.json`.
+- Tabla/listado con señales mínimas:
+  - prioridad
+  - candidato de historia
+  - estado de draft
+  - señal YT-first (si existe)
+- Acciones iniciales solo informativas (sin mutate).
+
+### Non-goals
+
+- No workflow de aprobación completo.
+- No auth enterprise (solo guardrail básico si aplica).
+
+### Done criteria
+
+- Vista ops renderiza handoff con empty/error states.
+- Queda documentado cómo usa `editorial_latest.json`.
+
+### Riesgos
+
+- Contrato de `editorial_latest.json` incompleto.
+- Mezclar vista interna con rutas públicas.
+
+### Checks sugeridos
+
+- `npm run dev` + validación manual en `/ops`.
+- Snapshot JSON de ejemplo para test local controlado.
+
+---
+
+## PR-4 (condicional) — FastAPI read surface y switch de fuente
+
+### Goal
+
+Crear seam HTTP estable para que frontend deje de leer archivos directos en runtime y pase a consumir read API.
+
+### Cuándo activar este PR condicional
+
+Activar solo si se cumple al menos uno:
+
+- deploy bloqueado por dependencia de filesystem local
+- necesidad real de caching/TTL desacoplado del renderer
+- segundo consumidor productivo (además del site)
+
+### Why now
+
+Permite desacoplar despliegue web de filesystem local y prepara publicación continua, pero no debe adelantarse a la estabilización de contrato + adapter.
+
+### Scope
+
+- Nueva app API mínima (ej. `apps/news_api/`) con endpoints read-only:
+  - `GET /api/frontpage`
+  - `GET /api/stories/latest`
+  - `GET /api/editorial/handoff`
+  - `GET /api/story/{id}`
+  - `GET /api/topic/{slug}`
+- Adapter compartido o duplicación mínima controlada para mapear índices -> payloads API.
+- Cambiar `apps/news_site` para usar fetch a API (con fallback local opcional detrás de flag).
+
+### Non-goals
+
+- Sin publish automation final.
+- Sin persistencia nueva en DB.
+
+### Done criteria
+
+- Frontend renderiza contenido desde API.
+- Contratos de respuesta documentados (tipos + ejemplo JSON).
+- Errores 404/500 con respuestas coherentes.
+
+### Riesgos
+
+- Duplicación de mapping en site y API.
+- Caching ambiguo entre Next y FastAPI.
+
+### Checks sugeridos
+
+- `uvicorn ...` + `curl` a endpoints.
+- `npm run build` del sitio consumiendo API local.
+
+---
+
+
+## Comparativa directa vs `shadcn/next-contentlayer`
+
+Referencia comparada: plantilla `Next.js + Contentlayer` de `shadcn/next-contentlayer` (app dir, MDX file-source, Tailwind, dark mode).
+
+### Qué encaja bien (reusar)
+
+- Estructura App Router (`app/`, `layout.tsx`, rutas dinámicas).
+- Setup base de Tailwind y tema.
+- Convención de componentes de presentación y MDX rendering opcional para páginas estáticas.
+
+### Qué no encaja como source-of-truth (adaptar o descartar)
+
+- `contentlayer.config.js` y `content/posts/**/*.mdx` como autoridad editorial primaria.
+- Uso de `allPosts`/`allPages` generado por Contentlayer para poblar home/story en runtime productivo.
+- Rutas y slugs derivados de flattened paths de MDX como identificador canónico.
+
+### Gap analysis (template vs objetivo del repo)
+
+1. **Modelo de datos**
+   - Template: MDX local (`Post`, `Page`) con campos mínimos (title/description/date).
+   - Este repo: artefactos compactos (`news_recent_refs`, `news_recent_groups`, `editorial_latest`) como seam canónico.
+
+2. **Flujo editorial**
+   - Template: publicación manual por archivo.
+   - Este repo: pipeline semi-automático + handoff humano de última milla.
+
+3. **Contrato público**
+   - Template: implícito en tipos Contentlayer.
+   - Este repo: debe ser explícito y mínimo (`frontpage/topic/story/editorial_handoff`).
+
+4. **Ops surface**
+   - Template: no incluye panel de handoff editorial.
+   - Este repo: `/ops` es requisito para priorización humana.
+
+### Decisión de implementación
+
+- Usar `shadcn/next-contentlayer` como **shell de UI/estructura**, no como cerebro editorial.
+- Mantener Contentlayer sólo para contenido estático auxiliar (ej. about/FAQ), nunca para feed/editorial truth.
+- Forzar adapter único desde índices compactos hacia view models públicos.
+
+### Mapping de archivos del template (keep/adapt/discard)
+
+- **Keep/Adapt**
+  - `app/layout.tsx`
+  - `app/globals.css`
+  - `components/theme-provider.tsx`
+  - `components/mode-toggle.tsx`
+
+- **Discard para ruta canónica de noticias**
+  - `content/posts/**/*.mdx`
+  - `app/posts/[...slug]/page.tsx` (si depende de `allPosts`)
+  - `contentlayer.config.js` como fuente de historias de portada
+
+- **Optional**
+  - `components/mdx-components.tsx` solo para páginas estáticas no editoriales
+
+
+## Reglas transversales (desde PR-1)
+
+1. **PR pequeño y reversible**: objetivo único, diff acotado.
+2. **Sin drift de source-of-truth**: nunca mover gobernanza editorial al frontend.
+3. **Evidencia runtime obligatoria**: comando + salida + screenshot cuando aplique UI.
+4. **Pruning continuo**: todo componente importado debe justificar existencia.
+5. **Compatibilidad contracts-first**: si cambia mapping, documentar en el PR y en README del app.
+
+---
+
+## Definition of Done del milestone completo
+
+> Regla de cierre: si para entender el estado operativo hacen falta múltiples scripts/runbooks fuera del README canónico, el milestone no está cerrado.
+
+
+- Existe frontend público funcional con estilo de medio.
+- Existe superficie ops mínima para handoff humano.
+- El frontend puede operar primero con archivos y luego con API read-only sin rediseño.
+- No se introdujo CMS ni DB editorial paralela.
+- Queda un “golden path” claro de ejecución local para demo en menos de 10 minutos.


### PR DESCRIPTION
### Motivation

- Provide an actionable guide and executable runbook to build a newspaper-style public site using `shadcn/next-contentlayer` as a UI shell while keeping the existing pipeline as source-of-truth. 
- Make explicit the adapter seam and required compact artifact indexes (`news_recent_refs_latest.jsonl`, `news_recent_groups_latest.jsonl`, `editorial_latest.json`) to avoid introducing a new CMS or editorial DB. 
- Define a small sequence of reversible PRs (bootstrap site, newspaper skin, ops surface, optional API) and pruning rules to avoid template bloat.

### Description

- Added `codex_newspaper_skin_guide.md` with constraints, allowed external repos, deliverables, mapping rules, and a short prompt to bootstrap Codex work for the sprint. 
- Added `docs/runbooks/pr9-newspaper-skin-implementation-prs.md` with a concrete PR plan (PR-1..PR-4), goals, scopes, done criteria, risks, and checks for implementing the newspaper skin and adapter. 
- Updated `docs/runbooks/README.md` to include the new `pr9-newspaper-skin-implementation-prs.md` entry. 
- Documented the decision to reuse `shadcn/next-contentlayer` as shell only, keep Contentlayer for static auxiliaries, and enforce an explicit adapter from storage indexes to frontend view models.

### Testing

- No automated tests were added or run for these documentation changes. 
- Changes are documentation-only and require downstream PRs to include runtime checks such as `npm run dev`/`npm run build` and adapter validation scripts as listed in the runbook.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c4b5b834832dbb665c6e6a58f528)