### PR TITLE
news_editorial: promote drafts to validated buses, add draft_bus_writer, prefer buses in handoff index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ pf-article: ## Force PF over per-article pfin file
 
 
 
-s05:       ## Stage 05 — explode PF outputs → drafts + enqueue generate
+s05:       ## Stage 05 — build draft buses, optional mirrors + enqueue generate
 	@$(_env_prefix) $(PYTHON) -m apps.news_editorial.src.news_editorial.stage05_explode_pf_outputs
 
 s06:       ## Stage 06 — build news_piece_brief.v1 seam from PF seed_ideas

--- a/apps/news_editorial/README.md
+++ b/apps/news_editorial/README.md
@@ -1,44 +1,99 @@
-# news_editorial (PR4b owner module)
+# news_editorial
 
-`apps/news_editorial` is the explicit owner module for the editorial structuring layer in the migration plan.
+`apps/news_editorial` owns the editorial generation and handoff lane. The lane is being kept compatible with the current PromptFlow runtime while its contracts are made explicit in the same artifact ladder used elsewhere in Media Monitor.
 
-This PR is additive: it clarifies ownership and operator entrypoints while preserving the current runtime path.
+## Editorial doctrine
+
+The editorial lane is a subsystem boundary, not a collection of PromptFlow output folders.
+
+```text
+digest runtime input
+  -> promptflow_runner
+  -> piece_brief_builder
+  -> draft_builder
+  -> handoff_index_builder
+```
+
+Artifact levels:
+
+| Level | Editorial artifacts | Role |
+| --- | --- | --- |
+| Level 0 runtime evidence | `data/digest_jsonls/*`, `data/pf_out/*`, editorial rows in `data/quarantine/*` | Operational inputs, raw generation output, and failure evidence. These are not the editorial contract. |
+| Level 1 contract buses | `storage/buses/news_piece_brief/v1/*`, `storage/buses/news_article_draft/v1/*`, `storage/buses/news_yt_script_draft/v1/*` | Schema-valid editorial contracts for downstream tooling. |
+| Level 2 access/decision index | `storage/indexes/editorial_latest.json` | Human/operator handoff surface and compact status index. |
+| Level 3 public snapshot | `apps/news_site/public/data/editorial_latest.json` when exported | Hardened snapshot for static/public consumers. |
+
+Current doctrine:
+
+- Raw PromptFlow output in `data/pf_out/*` is Level 0 runtime evidence only.
+- `news_piece_brief.v1` is the primary editorial contract today.
+- `data/drafts/*` is an optional transitional Level 0 mirror; draft buses are the canonical downstream draft surface.
+- `editorial_latest.json` is the operator/human decision surface.
+- Legacy fallback is emergency/support behavior and must remain visible through metrics and quarantine evidence.
+
+## Named components
+
+1. **promptflow_runner** — `stage04_promptflow_run.py`
+   - Reads `data/digest_jsonls/<DIGEST_AT>.jsonl`.
+   - Runs PromptFlow through the existing CLI/runtime.
+   - Writes raw generation output to `data/pf_out/pfout_<DIGEST_AT>*.jsonl`.
+2. **piece_brief_builder** — `stage06_build_piece_briefs.py`
+   - Reads PromptFlow runtime output.
+   - Normalizes editorial seed ideas.
+   - Writes schema-valid `news_piece_brief.v1` rows to `storage/buses/news_piece_brief/v1/*`.
+3. **draft_builder** — `stage05_explode_pf_outputs.py`
+   - Prefers `news_piece_brief.v1` as canonical input.
+   - Writes schema-valid draft rows to `storage/buses/news_article_draft/v1/*` and, when requested by format candidates, `storage/buses/news_yt_script_draft/v1/*`.
+   - Writes current draft mirrors under `data/drafts/<DIGEST_AT>/*` when `WRITE_DRAFT_MIRROR` is enabled.
+   - May use legacy PF cluster packaging only as emergency fallback.
+4. **handoff_index_builder** — `scripts/build_editorial_access_indexes.py`
+   - Builds `storage/indexes/editorial_latest.json` as the compact operator view over briefs, drafts, and fallback status.
+   - Reads draft buses first and uses `data/drafts/*` only as an explicit transition fallback.
+   - Emits `contract_inputs` and `fallback_inputs` so operators can see which Level 1 buses or Level 0 fallbacks contributed to the handoff.
 
 ## Ownership declaration
 
 ### Owned runtime/raw boundaries
+
 - `flow/` (PromptFlow definition and editorial generation logic)
-- `data/digest_jsonls/*` (operational editorial input seam today)
-- `data/pf_out/*` (PromptFlow output seam today)
-- `data/drafts/*` (downstream editorial-derived drafts after stage05)
-- `data/quarantine/*` entries produced by editorial stages (`V03`, `V05`)
+- `data/digest_jsonls/*` (current operational editorial input seam)
+- `data/pf_out/*` (Level 0 PromptFlow runtime output)
+- `data/drafts/*` (transitional draft mirror/output surface)
+- `data/quarantine/*` entries produced by editorial stages (`V03`, `V05`, and related editorial fallbacks)
 
 ### Buses consumed
-- `storage/buses/news_digest_group/v1/*` (structured digest groups when available)
-- legacy digest input seam `data/digest_jsonls/<DIGEST_AT>.jsonl` remains active source of truth for current runtime
 
-### Buses intended to be written by editorial adapters
-- `news_topic_cluster.v1`
-- `news_seed_idea.v1` (expandido de forma backward-compatible con campos editoriales: `format_candidates`, `working_title`, `angle`, `why_now`, `supporting_refs`, `risk_notes`)
-- `news_seed_card.v1`
+- `storage/buses/news_digest_group/v1/*` when available
+- Current runtime seam: `data/digest_jsonls/<DIGEST_AT>.jsonl`
 
-(These remain planned adapter outputs; this PR does not change contract shapes nor replace runtime.)
+### Buses written today
 
+- `storage/buses/news_piece_brief/v1/*`
+- `storage/buses/news_article_draft/v1/*`
+- `storage/buses/news_yt_script_draft/v1/*`
 
-## Implementation location (PR4d)
-Editorial primary implementation now lives under:
+### Buses planned for later PRs
+
+- `editorial_event.v1` or equivalent fallback/event stream
+
+## Implementation source of truth
+
+Editorial primary implementation lives under:
+
 - `apps/news_editorial/src/news_editorial/stage04_promptflow_run.py`
 - `apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py`
 - `apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py`
+- `apps/news_editorial/src/news_editorial/draft_bus_writer.py`
 - `apps/news_editorial/src/news_editorial/{ids,io,db,slugs}.py`
 
 Compatibility wrappers remain at:
+
 - `legacy/stage04_promptflow_run.py`
 - `legacy/stage05_explode_pf_outputs.py`
 
-`flow/` remains in its current top-level location for runtime safety and is treated as an editorial-owned transitional seam in this PR.
+`flow/` remains at the repo root for runtime safety and is treated as an editorial-owned transitional seam.
 
-## Entrypoint
+## Operator entrypoint
 
 Use owner wrapper:
 
@@ -47,32 +102,35 @@ apps/news_editorial/entrypoints/run_editorial_owner.sh
 ```
 
 Wrapper delegates to canonical runtime targets:
-1. `make s04`
-2. `make s06`
-3. `make s05`
 
+1. `make s04` — PromptFlow runner
+2. `make s06` — piece brief builder
+3. `make s05` — draft builder with legacy fallback
+4. `make build-editorial-access-indexes` — handoff index builder, unless `RUN_EXPORTS=0`
 
-## Contrato editorial actualizado (`news_seed_idea.v1`)
-- Se mantiene **la misma versión `v1`** para preservar compatibilidad con productores/consumidores actuales.
-- Los nuevos campos editoriales de decisión se agregan como opcionales en el esquema:
+## Updated editorial contract (`news_seed_idea.v1`)
+
+- The same `v1` version is preserved for compatibility with current producers and consumers.
+- Optional editorial decision fields may be populated:
   - `format_candidates`: `article` | `yt_script` | `both`
   - `working_title`
   - `angle`
   - `why_now`
   - `supporting_refs`
   - `risk_notes`
-- Recomendación operativa: para nuevos flujos editoriales, poblar estos campos como mínimo para habilitar decisión de formato y priorización.
+- For new editorial flows, populate these fields where possible to enable format decisions and prioritization.
 
-## External dependency boundary (explicit)
+## External dependency boundary
+
 - PromptFlow runtime/env/connectivity is an external dependency boundary for this module.
-- Current runtime keeps PF invocation in canonical make target logic.
-- This PR documents dependency ownership but does not solve PF runtime connectivity.
+- Current runtime keeps PromptFlow invocation in canonical make target logic.
+- This documentation clarifies ownership but does not replace PromptFlow or solve runtime connectivity.
 
 See operational details in [`runbook.md`](./runbook.md).
 
-## Non-goals in PR4b
-- No replacement of `bin/run_hour.sh`.
-- No replacement of `make s04` / `make s05`.
-- No PromptFlow refactor.
-- No schema edits under `contracts/schemas`.
-- No ownership migration for `news_enrich` (reserved for PR4c).
+## Non-goals for this closure
+
+- No PromptFlow replacement.
+- No file moves.
+- No UI work.
+- No fallback deletion.

--- a/apps/news_editorial/entrypoints/run_editorial_owner.sh
+++ b/apps/news_editorial/entrypoints/run_editorial_owner.sh
@@ -14,15 +14,15 @@ usage() {
   cat <<USAGE
 run_editorial_owner.sh
 
-Editorial owner wrapper (PR4b).
+Editorial owner wrapper.
 - Keeps canonical runtime intact by delegating to existing make targets.
-- Orchestrates editorial layer only: s04 -> s06 -> s05.
+- Orchestrates editorial lane: s04 -> s06 -> s05 -> build-editorial-access-indexes.
 
 Env knobs:
   DIGEST_AT  Hour bucket (YYYYMMDDTHH). Default: current UTC hour.
   DRY_RUN    Passed to make. Default: 0.
   PF_MODE    Passed to make s04 (legacy/new/auto). Default: legacy.
-  RUN_EXPORTS  1 to run exports after s05, 0 to skip. Default: 1.
+  RUN_EXPORTS  1 to build the editorial handoff index after s05, 0 to skip. Default: 1.
 
 Flags:
   --dry-run  Print commands without executing.
@@ -46,7 +46,7 @@ run_cmd() {
   "$@"
 }
 
-echo "[editorial-owner] digest_at=${DIGEST_AT} dry_run=${DRY_RUN} pf_mode=${PF_MODE}"
+echo "[editorial-owner] digest_at=${DIGEST_AT} dry_run=${DRY_RUN} pf_mode=${PF_MODE} run_exports=${RUN_EXPORTS}"
 run_cmd make s04 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN" PF_MODE="$PF_MODE"
 run_cmd make s06 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"
 run_cmd make s05 DIGEST_AT="$DIGEST_AT" DRY_RUN="$DRY_RUN"

--- a/apps/news_editorial/runbook.md
+++ b/apps/news_editorial/runbook.md
@@ -1,39 +1,108 @@
-# news_editorial runbook (PR4b owner module)
+# news_editorial runbook
 
 ## Purpose
-`apps/news_editorial` is now the explicit owner for editorial structuring and generation boundaries.
 
-PR4b establishes module ownership and a stable operator entrypoint while keeping legacy runtime behavior unchanged.
+`apps/news_editorial` owns the editorial lane from digest runtime input through human/operator handoff. The lane keeps the current PromptFlow runtime intact, but the subsystem boundary is now described as an artifact ladder:
 
-## Scope owned by news_editorial
+```text
+Level 0 runtime evidence -> Level 1 contract buses -> Level 2 decision index -> Level 3 public snapshot
+```
 
-### Owned paths
-- `flow/`
-- `data/digest_jsonls/*`
-- `data/pf_out/*`
-- `data/drafts/*`
-- editorial-related quarantine entries under `data/quarantine/*`
+The most important operating rule is:
 
-### Seams consumed
-- Canonical runtime seam: `data/digest_jsonls/<DIGEST_AT>.jsonl`
-- Optional structured seam: `storage/buses/news_digest_group/v1/*`
+```text
+PromptFlow output is runtime evidence, not the editorial contract.
+news_piece_brief.v1 is the primary editorial contract.
+editorial_latest.json is the human/operator decision surface.
+```
 
-### Seams/exports targeted (future adapters)
-- `news_topic_cluster.v1`
-- `news_seed_idea.v1` (expandido de forma backward-compatible con campos editoriales: `format_candidates`, `working_title`, `angle`, `why_now`, `supporting_refs`, `risk_notes`)
-- `news_seed_card.v1`
+## Artifact ladder
 
+| Level | Path(s) | Operator meaning |
+| --- | --- | --- |
+| Level 0 runtime | `data/digest_jsonls/*`, `data/pf_out/*`, editorial `data/quarantine/*` rows | Evidence and emergency diagnostics. These paths are allowed to be ugly and runtime-specific. |
+| Level 1 contracts | `storage/buses/news_piece_brief/v1/*`, `storage/buses/news_article_draft/v1/*`, `storage/buses/news_yt_script_draft/v1/*` | Schema-valid editorial artifacts that downstream code should prefer. |
+| Level 2 handoff | `storage/indexes/editorial_latest.json` | Compact decision/status surface for humans and agents. |
+| Level 3 snapshot | `apps/news_site/public/data/editorial_latest.json` when published | Hardened public/static handoff copy. |
 
-## Implementation source of truth (PR4d)
-- `apps/news_editorial/src/news_editorial/stage04_promptflow_run.py`
-- `apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py`
-- `apps/news_editorial/src/news_editorial/{ids,io,db,slugs}.py`
+## Four named components
 
-Legacy modules are thin compatibility wrappers:
-- `legacy/stage04_promptflow_run.py`
-- `legacy/stage05_explode_pf_outputs.py`
+### 1. promptflow_runner
 
-`flow/` is intentionally left at repo root in PR4d for runtime safety and documented as editorial-owned transitional seam.
+Implementation: `apps/news_editorial/src/news_editorial/stage04_promptflow_run.py`
+
+```text
+data/digest_jsonls/<DIGEST_AT>.jsonl
+  -> PromptFlow CLI/runtime
+  -> data/pf_out/pfout_<DIGEST_AT>*.jsonl
+```
+
+Responsibilities:
+
+- Locate current digest JSONL input.
+- Run the existing PromptFlow CLI flow.
+- Copy/normalize the raw PromptFlow output into `data/pf_out/*`.
+
+Boundary rule: `data/pf_out/*` is Level 0 runtime output. Do not treat it as the stable editorial contract.
+
+### 2. piece_brief_builder
+
+Implementation: `apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py`
+
+```text
+data/pf_out/*
+  -> normalized seed ideas
+  -> storage/buses/news_piece_brief/v1/*.jsonl
+```
+
+Responsibilities:
+
+- Read PromptFlow runtime output.
+- Normalize seed ideas and editorial decision fields.
+- Emit schema-valid `news_piece_brief.v1` rows.
+- Quarantine schema failures with enough evidence to debug the run.
+
+Boundary rule: `news_piece_brief.v1` is the primary editorial Level 1 contract today.
+
+### 3. draft_builder
+
+Implementation: `apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py` with bus validation/writes in `apps/news_editorial/src/news_editorial/draft_bus_writer.py`
+
+```text
+storage/buses/news_piece_brief/v1/* preferred
+  -> storage/buses/news_article_draft/v1/*.jsonl
+  -> storage/buses/news_yt_script_draft/v1/*.jsonl when format candidates request video
+  -> data/drafts/<DIGEST_AT>/*.jsonl optional transitional mirror
+```
+
+Responsibilities:
+
+- Prefer `news_piece_brief.v1` inputs when present.
+- Build schema-valid draft bus records before writing the transitional mirror.
+- Keep `data/drafts/*` as an optional mirror controlled by `WRITE_DRAFT_MIRROR`; it is not the canonical draft contract.
+- Use legacy PF cluster packaging only when the configured fallback policy allows it.
+- Emit metrics/quarantine evidence when fallback activates.
+
+Boundary rule: `news_article_draft.v1` and `news_yt_script_draft.v1` are the Level 1 draft contracts. `data/drafts/*` is a transitional Level 0 mirror.
+
+### 4. handoff_index_builder
+
+Implementation: `scripts/build_editorial_access_indexes.py`
+
+```text
+editorial buses + transitional draft/fallback evidence
+  -> storage/indexes/editorial_latest.json
+```
+
+Responsibilities:
+
+- Build the compact handoff/status document for operators and agents.
+- Read `news_piece_brief.v1`, `news_article_draft.v1`, and `news_yt_script_draft.v1` buses first.
+- Fall back to `data/drafts/*` only when draft bus rows are absent.
+- Surface brief/draft/fallback counts, latest artifact pointers, and explicit input provenance.
+- Keep fallback visible instead of requiring operators to inspect random Level 0 folders.
+
+Boundary rule: `editorial_latest.json` is the Level 2 human/operator decision surface. Its `contract_inputs` fields show Level 1 bus use, and its `fallback_inputs` fields show Level 0 transitional sources such as `pf_out`, `data_drafts`, or `quarantine`.
 
 ## Operator entrypoint
 
@@ -42,9 +111,11 @@ apps/news_editorial/entrypoints/run_editorial_owner.sh
 ```
 
 Wrapper behavior:
-1. Executes `make s04 DIGEST_AT=<...> DRY_RUN=<...> PF_MODE=<...>`
-2. Executes `make s06 DIGEST_AT=<...> DRY_RUN=<...>`
-3. Executes `make s05 DIGEST_AT=<...> DRY_RUN=<...>`
+
+1. Executes `make s04 DIGEST_AT=<...> DRY_RUN=<...> PF_MODE=<...>`.
+2. Executes `make s06 DIGEST_AT=<...> DRY_RUN=<...>`.
+3. Executes `make s05 DIGEST_AT=<...> DRY_RUN=<...>`.
+4. Executes `make build-editorial-access-indexes DIGEST_AT=<...>` unless `RUN_EXPORTS=0`.
 
 ### Examples
 
@@ -57,39 +128,66 @@ DIGEST_AT=20260313T15 apps/news_editorial/entrypoints/run_editorial_owner.sh --d
 
 # Force PF article mode passthrough
 DIGEST_AT=20260313T15 PF_MODE=new apps/news_editorial/entrypoints/run_editorial_owner.sh
+
+# Skip handoff index/export step for local debugging
+DIGEST_AT=20260313T15 RUN_EXPORTS=0 apps/news_editorial/entrypoints/run_editorial_owner.sh
 ```
 
+## Handoff input provenance
+
+`storage/indexes/editorial_latest.json` includes explicit input provenance:
+
+```json
+{
+  "contract_inputs": {
+    "piece_brief_bus": true,
+    "article_draft_bus": true,
+    "yt_script_draft_bus": true
+  },
+  "fallback_inputs": {
+    "pf_out": false,
+    "data_drafts": false,
+    "quarantine": true
+  }
+}
+```
+
+Expected ED3 behavior:
+
+- If draft bus rows exist, the handoff index reads them instead of `data/drafts/*`.
+- If draft bus rows are absent, the handoff index may fall back to `data/drafts/*` and sets `fallback_inputs.data_drafts=true`.
+- If raw PF output is missing but buses exist, the handoff index still builds; `seed_ideas_emitted` may be `0`, but bus-backed briefs/drafts keep the handoff usable.
+
 ## Fallback and no-op behavior
-- `make s04` already performs no-op when suitable PF input is missing.
-- `make s06` may emit zero briefs when PF outputs or seed_ideas are missing/invalid.
-- `make s05` consumes briefs when available and falls back to legacy cluster packaging when briefs are absent.
-- This wrapper does not alter stage semantics; it only centralizes editorial ownership at module level.
 
+- `make s04` performs no-op when suitable digest input is missing.
+- `make s06` may emit zero briefs when PF outputs or seed ideas are missing/invalid.
+- `make s05` consumes briefs when available, writes validated draft buses first, mirrors to `data/drafts/*` when enabled, and falls back to legacy cluster packaging when briefs are absent and fallback policy allows it.
+- Default fallback mode is `LEGACY_EDITORIAL_FALLBACK=emergency`.
+- Set `LEGACY_EDITORIAL_FALLBACK=off` to fail fast when `news_piece_brief.v1` is missing.
+- Every fallback activation must remain visible in metrics/quarantine evidence; fallback is migration telemetry, not normal success.
 
-## Contrato editorial actualizado (`news_seed_idea.v1`)
-- Se mantiene **la misma versión `v1`** para preservar compatibilidad con productores/consumidores actuales.
-- Los nuevos campos editoriales de decisión se agregan como opcionales en el esquema:
+## Updated editorial contract (`news_seed_idea.v1`)
+
+- The same `v1` version is preserved for compatibility with current producers and consumers.
+- Optional editorial decision fields may be populated:
   - `format_candidates`: `article` | `yt_script` | `both`
   - `working_title`
   - `angle`
   - `why_now`
   - `supporting_refs`
   - `risk_notes`
-- Recomendación operativa: para nuevos flujos editoriales, poblar estos campos como mínimo para habilitar decisión de formato y priorización.
+- For new editorial flows, populate these fields where possible to enable format decisions and prioritization.
 
 ## External dependency boundary
-- PromptFlow runtime (`PF_PYTHON`/conda env and run dir resolution) remains external dependency.
+
+- PromptFlow runtime (`PF_PYTHON`/conda env and run dir resolution) remains an external dependency.
 - Failures in PromptFlow availability or connectivity are runtime/environment issues, not ownership-definition issues.
 
 ## Constraints respected
+
 - No replacement of `bin/run_hour.sh`.
 - No replacement of `make s04`/`make s06`/`make s05`.
 - No refactor of PromptFlow internals.
-- No changes to schema definitions.
+- No schema definition changes.
 - No file moves/deletes in legacy.
-
-
-## Legacy fallback policy (stage05)
-- Default mode: `LEGACY_EDITORIAL_FALLBACK=emergency` (fallback allowed only as emergency path).
-- Set `LEGACY_EDITORIAL_FALLBACK=off` to fail fast when `news_piece_brief.v1` is missing.
-- Every fallback activation writes explicit quarantine evidence (`legacy_fallback_emergency_activated`).

--- a/apps/news_editorial/src/news_editorial/draft_bus_writer.py
+++ b/apps/news_editorial/src/news_editorial/draft_bus_writer.py
@@ -1,0 +1,182 @@
+"""Schema validation and bus writing for editorial draft contracts."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Literal
+
+from jsonschema import Draft202012Validator
+
+from . import io as bio
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCHEMA_DIR = REPO_ROOT / "contracts" / "schemas"
+STORAGE_DIR = REPO_ROOT / "storage"
+ARTICLE_BUS_DIR = STORAGE_DIR / "buses" / "news_article_draft" / "v1"
+YT_SCRIPT_BUS_DIR = STORAGE_DIR / "buses" / "news_yt_script_draft" / "v1"
+
+DraftKind = Literal["article", "yt_script"]
+
+
+class DraftBusValidationError(ValueError):
+    """Raised when an editorial draft bus record fails JSON Schema validation."""
+
+
+def _safe_id(value: str, fallback: str) -> str:
+    raw = value.strip() or fallback
+    safe = re.sub(r"[^A-Za-z0-9_.:-]+", "_", raw).strip("_")
+    return safe or fallback
+
+
+def _load_schema(schema_name: str, *, schema_dir: Path = SCHEMA_DIR) -> dict[str, Any]:
+    with (schema_dir / schema_name).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _validate(record: dict[str, Any], schema_name: str, *, schema_dir: Path = SCHEMA_DIR) -> dict[str, Any]:
+    validator = Draft202012Validator(_load_schema(schema_name, schema_dir=schema_dir))
+    errors = sorted(validator.iter_errors(record), key=lambda error: list(error.path))
+    if errors:
+        messages = "; ".join(error.message for error in errors)
+        raise DraftBusValidationError(messages)
+    return record
+
+
+def validate_article_draft(record: dict[str, Any], *, schema_dir: Path = SCHEMA_DIR) -> dict[str, Any]:
+    """Validate a record against contracts/schemas/news_article_draft.v1.json."""
+    return _validate(record, "news_article_draft.v1.json", schema_dir=schema_dir)
+
+
+def validate_yt_script_draft(record: dict[str, Any], *, schema_dir: Path = SCHEMA_DIR) -> dict[str, Any]:
+    """Validate a record against contracts/schemas/news_yt_script_draft.v1.json."""
+    return _validate(record, "news_yt_script_draft.v1.json", schema_dir=schema_dir)
+
+
+def article_bus_path(record: dict[str, Any], *, bus_dir: Path = ARTICLE_BUS_DIR) -> Path:
+    draft_id = _safe_id(str(record.get("draft_id") or ""), "article_draft")
+    return bus_dir / f"{draft_id}.jsonl"
+
+
+def yt_script_bus_path(record: dict[str, Any], *, bus_dir: Path = YT_SCRIPT_BUS_DIR) -> Path:
+    script_id = _safe_id(str(record.get("script_id") or ""), "yt_script_draft")
+    return bus_dir / f"{script_id}.jsonl"
+
+
+def _citation_url(citation: dict[str, Any]) -> str:
+    return str(citation.get("url") or "").strip()
+
+
+def _source_ref_id(citation: dict[str, Any], ordinal: int, fallback: str) -> str:
+    return _safe_id(
+        str(citation.get("source_ref_id") or citation.get("index_id") or citation.get("source") or ""),
+        f"{fallback}_ref_{ordinal}",
+    )
+
+
+def article_draft_from_stage05(draft: dict[str, Any]) -> dict[str, Any]:
+    """Promote the stage05 draft mirror shape into news_article_draft.v1."""
+    meta = draft.get("meta") if isinstance(draft.get("meta"), dict) else {}
+    brief_id = _safe_id(str(meta.get("brief_id") or draft.get("cluster_id") or draft.get("index_id") or ""), "legacy_brief")
+    index_id = _safe_id(str(draft.get("index_id") or brief_id), brief_id)
+    title = str(draft.get("headline") or draft.get("topic") or index_id).strip()
+    dek = str(draft.get("dek") or draft.get("topic") or title).strip()
+    lede = dek or title
+    section_heading = str(draft.get("topic") or "What matters").strip() or "What matters"
+
+    citations = []
+    for ordinal, citation in enumerate([c for c in (draft.get("citations") or []) if isinstance(c, dict)], start=1):
+        url = _citation_url(citation)
+        if not url:
+            continue
+        citations.append(
+            {
+                "citation_id": f"c{ordinal}",
+                "claim_text": title,
+                "source_ref_id": _source_ref_id(citation, ordinal, index_id),
+                "url": url,
+            }
+        )
+
+    return {
+        "schema_name": "news_article_draft.v1",
+        "schema_status": "experimental_structured",
+        "draft_id": _safe_id(f"article_{brief_id}_{index_id}", f"article_{index_id}"),
+        "brief_id": brief_id,
+        "title": title,
+        "dek": dek,
+        "lede": lede,
+        "sections": [
+            {
+                "section_id": "sec_1",
+                "heading": section_heading,
+                "summary": lede,
+            }
+        ],
+        "body_markdown": f"# {title}\n\n{lede}",
+        "citations": citations,
+        "fact_check_flags": [],
+        "revision_notes": [],
+    }
+
+
+def yt_script_draft_from_stage05(draft: dict[str, Any]) -> dict[str, Any]:
+    """Promote the stage05 draft mirror shape into news_yt_script_draft.v1."""
+    meta = draft.get("meta") if isinstance(draft.get("meta"), dict) else {}
+    brief_id = _safe_id(str(meta.get("brief_id") or draft.get("cluster_id") or draft.get("index_id") or ""), "legacy_brief")
+    index_id = _safe_id(str(draft.get("index_id") or brief_id), brief_id)
+    title = str(draft.get("headline") or draft.get("topic") or index_id).strip()
+    hook = str(draft.get("dek") or title).strip()
+    topic = str(draft.get("topic") or "What matters").strip() or "What matters"
+
+    citations = []
+    for ordinal, citation in enumerate([c for c in (draft.get("citations") or []) if isinstance(c, dict)], start=1):
+        url = _citation_url(citation)
+        if not url:
+            continue
+        citations.append(
+            {
+                "source_ref_id": _source_ref_id(citation, ordinal, index_id),
+                "url": url,
+                "usage_note": title,
+            }
+        )
+
+    return {
+        "schema_name": "news_yt_script_draft.v1",
+        "schema_status": "experimental_structured",
+        "script_id": _safe_id(f"yt_{brief_id}_{index_id}", f"yt_{index_id}"),
+        "brief_id": brief_id,
+        "title": title,
+        "thumbnail_hook": hook,
+        "cold_open": hook,
+        "segment_outline": [
+            {
+                "segment_id": "seg_1",
+                "heading": topic,
+                "beat": hook,
+                "estimated_seconds": 45,
+            }
+        ],
+        "full_script": f"[COLD OPEN]\n{hook}\n\n[SEGMENT 1]\n{title}",
+        "voice_notes": [],
+        "visual_notes": [],
+        "citations": citations,
+    }
+
+
+def write_article_draft(record: dict[str, Any], *, path: Path | None = None, bus_dir: Path = ARTICLE_BUS_DIR) -> Path:
+    """Validate and write one news_article_draft.v1 row to its bus."""
+    validated = validate_article_draft(record)
+    destination = path or article_bus_path(validated, bus_dir=bus_dir)
+    bio.atomic_write_jsonl(destination, [json.dumps(validated, ensure_ascii=False)])
+    return destination
+
+
+def write_yt_script_draft(record: dict[str, Any], *, path: Path | None = None, bus_dir: Path = YT_SCRIPT_BUS_DIR) -> Path:
+    """Validate and write one news_yt_script_draft.v1 row to its bus."""
+    validated = validate_yt_script_draft(record)
+    destination = path or yt_script_bus_path(validated, bus_dir=bus_dir)
+    bio.atomic_write_jsonl(destination, [json.dumps(validated, ensure_ascii=False)])
+    return destination

--- a/apps/news_editorial/src/news_editorial/stage04_promptflow_run.py
+++ b/apps/news_editorial/src/news_editorial/stage04_promptflow_run.py
@@ -1,6 +1,6 @@
-# legacy/04_promptflow_run.py
-# Execute Promptflow for the fixed hour. Input: data/digest_jsonls/pfin_<DIGEST_AT>.jsonl
-# Output: data/pf_out/pfout_<DIGEST_AT>.jsonl (overwrite idempotent)
+# promptflow_runner: execute PromptFlow for one digest hour.
+# Input: data/digest_jsonls/<DIGEST_AT>.jsonl (Level 0 runtime input).
+# Output: data/pf_out/pfout_<DIGEST_AT>.jsonl (Level 0 runtime evidence, overwrite idempotent).
 from __future__ import annotations
 
 import os
@@ -117,8 +117,9 @@ def run() -> int:
     except Exception:
         pass
 
-    # Input path
-    # pfin_path = PF_IN_DIR / f"pfin_{digest_id}.jsonl"
+    # Current runtime input path. Older PF article-mode runs used data/pf_in,
+    # but the editorial lane now treats data/digest_jsonls as the Level 0
+    # digest input seam for promptflow_runner.
     pfin_path = DATA_DIR / "digest_jsonls" / f"{digest_id}.jsonl"
     if not pfin_path.exists():
         try:

--- a/apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py
+++ b/apps/news_editorial/src/news_editorial/stage05_explode_pf_outputs.py
@@ -1,5 +1,6 @@
-# legacy/05_explode_pf_outputs.py
-# Explode PF clusters or briefs -> ArticleDraftV1, validate, and enqueue "generate".
+# draft_builder: promote drafts to Level 1 buses, then mirror/enqueue.
+# Prefer news_piece_brief.v1 as the editorial input contract; use legacy
+# PromptFlow cluster packaging only as configured emergency fallback.
 from __future__ import annotations
 
 import os
@@ -13,6 +14,13 @@ import pandas as pd
 
 from . import ids, db, slugs
 from . import io as bio
+from .draft_bus_writer import (
+    DraftBusValidationError,
+    article_draft_from_stage05,
+    write_article_draft,
+    write_yt_script_draft,
+    yt_script_draft_from_stage05,
+)
 
 try:
     # Optional strict validation if your models are wired
@@ -28,6 +36,8 @@ DIGEST_MAP_DIR = DATA_DIR / "digest_map"
 DRAFTS_BASE = DATA_DIR / "drafts"
 QUAR_DIR = DATA_DIR / "quarantine"
 BRIEFS_DIR = STORAGE_DIR / "buses" / "news_piece_brief" / "v1"
+ARTICLE_DRAFT_BUS_DIR = STORAGE_DIR / "buses" / "news_article_draft" / "v1"
+YT_SCRIPT_DRAFT_BUS_DIR = STORAGE_DIR / "buses" / "news_yt_script_draft" / "v1"
 
 
 # -------- Env helpers --------
@@ -49,7 +59,7 @@ def _env_float(name: str, default: float | None = None) -> float | None:
 
 
 def ensure_dirs():
-    for p in (PF_OUT_DIR, DIGEST_MAP_DIR, DRAFTS_BASE, QUAR_DIR, BRIEFS_DIR):
+    for p in (PF_OUT_DIR, DIGEST_MAP_DIR, DRAFTS_BASE, QUAR_DIR, BRIEFS_DIR, ARTICLE_DRAFT_BUS_DIR, YT_SCRIPT_DRAFT_BUS_DIR):
         p.mkdir(parents=True, exist_ok=True)
 
 
@@ -241,6 +251,50 @@ def _validate_and_package_draft(draft_obj: dict, run_id: str, source_reason: str
     return draft_obj, None
 
 
+def _target_formats_from_brief(brief: dict | None) -> list[str]:
+    if not brief:
+        return ["article"]
+    raw = brief.get("format_candidates")
+    values: list[str]
+    if isinstance(raw, list):
+        values = [str(v).strip() for v in raw if str(v).strip()]
+    else:
+        values = [str(raw).strip()] if str(raw or "").strip() else []
+    if "both" in values:
+        return ["article", "yt_script"]
+    if "yt_script" in values and "article" in values:
+        return ["article", "yt_script"]
+    if "yt_script" in values:
+        return ["yt_script"]
+    return ["article"]
+
+
+def _write_draft_buses(draft_record: dict, target_formats: list[str], run_id: str, bus_root: Path | None = None) -> tuple[list[Path], str | None]:
+    article_dir = (bus_root / "buses" / "news_article_draft" / "v1") if bus_root else ARTICLE_DRAFT_BUS_DIR
+    yt_dir = (bus_root / "buses" / "news_yt_script_draft" / "v1") if bus_root else YT_SCRIPT_DRAFT_BUS_DIR
+    written: list[Path] = []
+    try:
+        if "article" in target_formats:
+            article_record = article_draft_from_stage05(draft_record)
+            written.append(write_article_draft(article_record, bus_dir=article_dir))
+        if "yt_script" in target_formats:
+            yt_record = yt_script_draft_from_stage05(draft_record)
+            written.append(write_yt_script_draft(yt_record, bus_dir=yt_dir))
+    except (DraftBusValidationError, OSError) as e:
+        bio.append_jsonl(
+            quarantine_path("V05", run_id),
+            {
+                "reason": "draft_bus_write_failed",
+                "error": str(e),
+                "target_formats": target_formats,
+                "index_id": draft_record.get("index_id"),
+                "brief_id": (draft_record.get("meta") or {}).get("brief_id") if isinstance(draft_record.get("meta"), dict) else None,
+            },
+        )
+        return written, "draft_bus_write_failed"
+    return written, None
+
+
 # -------- Core --------
 def run() -> int:
     ensure_dirs()
@@ -248,6 +302,7 @@ def run() -> int:
     digest_at_env = os.getenv("DIGEST_AT")
     dry_run = _env_bool("DRY_RUN", False)
     null_sink = _env_bool("NULL_SINK", False)
+    write_draft_mirror = _env_bool("WRITE_DRAFT_MIRROR", True)
     run_id = os.getenv("RUN_ID")
     limit = _env_float("LIMIT", None)
     sample = _env_float("SAMPLE", None)
@@ -331,7 +386,9 @@ def run() -> int:
         df_groups = df_groups.head(int(limit))
 
     drafts_dir = (DATA_DIR / "_tmp" / "null" / "drafts" / digest_id) if null_sink else (DRAFTS_BASE / digest_id)
-    drafts_dir.mkdir(parents=True, exist_ok=True)
+    if write_draft_mirror:
+        drafts_dir.mkdir(parents=True, exist_ok=True)
+    bus_root = (DATA_DIR / "_tmp" / "null" / "storage") if null_sink else None
 
     total_refs = 0
     joined_refs = 0
@@ -356,13 +413,19 @@ def run() -> int:
                 continue
 
             index_id = str(draft_record.get("index_id") or "").strip()
+            bus_paths, bus_err = _write_draft_buses(draft_record, _target_formats_from_brief(brief), run_id, bus_root)
+            if bus_err:
+                bad_drafts += 1
+                continue
+
             out_path = drafts_dir / f"{index_id}.jsonl"
-            atomic_write_one_jsonl(out_path, draft_record)
+            if write_draft_mirror:
+                atomic_write_one_jsonl(out_path, draft_record)
             ok_drafts += 1
             joined_refs += 1
 
             if not dry_run:
-                payload = {"digest_id_hour": draft_record.get("digest_id_hour"), "index_id": index_id, "draft_path": str(out_path)}
+                payload = {"digest_id_hour": draft_record.get("digest_id_hour"), "index_id": index_id, "draft_path": str(out_path if write_draft_mirror else bus_paths[0])}
                 enqueued = False
                 for fn in ("push_work", "push_job", "enqueue_work", "enqueue_job"):
                     try:
@@ -448,13 +511,19 @@ def run() -> int:
                         bad_drafts += 1
                         continue
 
+                    bus_paths, bus_err = _write_draft_buses(draft_record, ["article"], run_id, bus_root)
+                    if bus_err:
+                        bad_drafts += 1
+                        continue
+
                     out_path = drafts_dir / f"{index_id}.jsonl"
-                    atomic_write_one_jsonl(out_path, draft_record)
+                    if write_draft_mirror:
+                        atomic_write_one_jsonl(out_path, draft_record)
                     ok_drafts += 1
                     joined_refs += 1
 
                     if not dry_run:
-                        payload = {"digest_id_hour": digest_ts, "index_id": index_id, "draft_path": str(out_path)}
+                        payload = {"digest_id_hour": digest_ts, "index_id": index_id, "draft_path": str(out_path if write_draft_mirror else bus_paths[0])}
                         enqueued = False
                         for fn in ("push_work", "push_job", "enqueue_work", "enqueue_job"):
                             try:
@@ -484,7 +553,12 @@ def run() -> int:
     except Exception:
         pass
 
-    print(f"[{stage_name}] digest_id={digest_id} drafts_ok={ok_drafts} bad={bad_drafts} joined={joined_refs}/{total_refs} -> {drafts_dir}")
+    mirror_msg = str(drafts_dir) if write_draft_mirror else "mirror_disabled"
+    print(
+        f"[{stage_name}] digest_id={digest_id} drafts_ok={ok_drafts} bad={bad_drafts} "
+        f"joined={joined_refs}/{total_refs} -> article_bus={ARTICLE_DRAFT_BUS_DIR} "
+        f"yt_bus={YT_SCRIPT_DRAFT_BUS_DIR} mirror={mirror_msg}"
+    )
     return 0
 
 

--- a/apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py
+++ b/apps/news_editorial/src/news_editorial/stage06_build_piece_briefs.py
@@ -1,3 +1,8 @@
+"""piece_brief_builder for the editorial lane.
+
+Reads Level 0 PromptFlow runtime output from data/pf_out and promotes
+validated editorial ideas into the Level 1 news_piece_brief.v1 bus.
+"""
 from __future__ import annotations
 
 import hashlib

--- a/scripts/build_editorial_access_indexes.py
+++ b/scripts/build_editorial_access_indexes.py
@@ -32,9 +32,28 @@ def _extract_digest_from_name(path: Path) -> str | None:
     return m.group(1) if m else None
 
 
-def _resolve_digest_id(data_dir: Path, digest_at: str | None) -> str | None:
+def _extract_digest_from_bus(path: Path, schema_name: str) -> str | None:
+    try:
+        for row in _iter_jsonl(path):
+            if str(row.get("schema_name") or "") != schema_name:
+                continue
+            digest_id = str(row.get("digest_id_hour") or "").strip()
+            if digest_id:
+                return digest_id
+    except Exception:
+        return None
+    return None
+
+
+def _resolve_digest_id(data_dir: Path, storage_dir: Path, digest_at: str | None) -> str | None:
     if digest_at:
         return digest_at.strip()
+
+    brief_bus = storage_dir / "buses" / "news_piece_brief" / "v1"
+    for p in sorted(brief_bus.glob("*.jsonl"), reverse=True):
+        did = _extract_digest_from_bus(p, "news_piece_brief.v1")
+        if did:
+            return did
 
     pf_out = data_dir / "pf_out"
     candidates = sorted(pf_out.glob("pfout_*.jsonl"), reverse=True)
@@ -58,24 +77,6 @@ def _count_seed_ideas(pf_files: list[Path]) -> int:
     return total
 
 
-def _count_briefs(brief_files: list[Path], digest_id: str) -> int:
-    count = 0
-    for bf in brief_files:
-        for row in _iter_jsonl(bf):
-            if str(row.get("schema_name") or "") != "news_piece_brief.v1":
-                continue
-            if str(row.get("digest_id_hour") or "") != digest_id:
-                continue
-            count += 1
-    return count
-
-
-def _count_drafts(drafts_dir: Path) -> int:
-    if not drafts_dir.exists():
-        return 0
-    return len(list(drafts_dir.glob("*.jsonl")))
-
-
 def _quarantine_metrics(quarantine_dir: Path, digest_id: str) -> tuple[int, int]:
     fallback_legacy_count = 0
     schema_failures = 0
@@ -94,6 +95,8 @@ def _status_for(metrics: dict[str, int]) -> str:
         return "degraded"
     if metrics["fallback_legacy_count"] > 0:
         return "fallback-heavy"
+    if metrics["briefs_emitted"] > 0 or metrics["drafts_emitted"] > 0:
+        return "ok"
     if metrics["seed_ideas_emitted"] == 0:
         return "degraded"
     return "ok"
@@ -162,6 +165,64 @@ def _latest_draft_records(drafts_dir: Path, limit: int = 10) -> tuple[list[dict[
     return article[-limit:], yt[-limit:]
 
 
+def _draft_record_from_article_bus(path: Path, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "index_id": str(row.get("draft_id") or ""),
+        "draft_id": str(row.get("draft_id") or ""),
+        "brief_id": str(row.get("brief_id") or ""),
+        "topic": "",
+        "headline": str(row.get("title") or ""),
+        "dek": str(row.get("dek") or ""),
+        "cluster_id": str(row.get("brief_id") or ""),
+        "schema_name": "news_article_draft.v1",
+    }
+
+
+def _draft_record_from_yt_bus(path: Path, row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": str(path),
+        "index_id": str(row.get("script_id") or ""),
+        "script_id": str(row.get("script_id") or ""),
+        "brief_id": str(row.get("brief_id") or ""),
+        "topic": "",
+        "headline": str(row.get("title") or ""),
+        "dek": str(row.get("cold_open") or row.get("thumbnail_hook") or ""),
+        "cluster_id": str(row.get("brief_id") or ""),
+        "schema_name": "news_yt_script_draft.v1",
+    }
+
+
+def _latest_draft_bus_records(
+    article_files: list[Path],
+    yt_files: list[Path],
+    digest_brief_ids: set[str],
+    limit: int = 10,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    article: list[dict[str, Any]] = []
+    yt: list[dict[str, Any]] = []
+
+    for path in article_files:
+        for row in _iter_jsonl(path):
+            if str(row.get("schema_name") or "") != "news_article_draft.v1":
+                continue
+            brief_id = str(row.get("brief_id") or "").strip()
+            if digest_brief_ids and brief_id not in digest_brief_ids:
+                continue
+            article.append(_draft_record_from_article_bus(path, row))
+
+    for path in yt_files:
+        for row in _iter_jsonl(path):
+            if str(row.get("schema_name") or "") != "news_yt_script_draft.v1":
+                continue
+            brief_id = str(row.get("brief_id") or "").strip()
+            if digest_brief_ids and brief_id not in digest_brief_ids:
+                continue
+            yt.append(_draft_record_from_yt_bus(path, row))
+
+    return article[-limit:], yt[-limit:]
+
+
 def _fallback_summary(quarantine_dir: Path, digest_id: str, limit: int = 20) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for qf in sorted(quarantine_dir.glob(f"V*{digest_id}*.jsonl")):
@@ -182,7 +243,7 @@ def _human_status(metrics: dict[str, int]) -> str:
         return "brief-gap"
     if metrics["drafts_emitted"] == 0 and metrics["briefs_emitted"] > 0:
         return "draft-gap"
-    if metrics["seed_ideas_emitted"] == 0:
+    if metrics["seed_ideas_emitted"] == 0 and metrics["briefs_emitted"] == 0 and metrics["drafts_emitted"] == 0:
         return "no-seed-ideas"
     return "ready"
 
@@ -238,7 +299,7 @@ def _build_action_candidates(
 
 
 def build_editorial_index(storage_dir: Path, data_dir: Path, digest_at: str | None = None) -> Path:
-    digest_id = _resolve_digest_id(data_dir, digest_at)
+    digest_id = _resolve_digest_id(data_dir, storage_dir, digest_at)
     built_at = _utc_now_compact()
     idx_dir = storage_dir / "indexes"
 
@@ -254,9 +315,21 @@ def build_editorial_index(storage_dir: Path, data_dir: Path, digest_at: str | No
                 "fallback_legacy_count": 0,
                 "schema_failures": 0,
             },
+            "contract_inputs": {
+                "piece_brief_bus": False,
+                "article_draft_bus": False,
+                "yt_script_draft_bus": False,
+            },
+            "fallback_inputs": {
+                "pf_out": False,
+                "data_drafts": False,
+                "quarantine": False,
+            },
             "pointers": {
                 "pf_outputs": [],
                 "brief_files": [],
+                "article_draft_bus_files": [],
+                "yt_script_draft_bus_files": [],
                 "draft_files": [],
                 "quarantine_files": [],
             },
@@ -276,13 +349,43 @@ def build_editorial_index(storage_dir: Path, data_dir: Path, digest_at: str | No
 
     pf_files = sorted((data_dir / "pf_out").glob(f"pfout_{digest_id}*.jsonl"))
     brief_files = sorted((storage_dir / "buses" / "news_piece_brief" / "v1").glob("*.jsonl"))
+    article_draft_bus_files = sorted((storage_dir / "buses" / "news_article_draft" / "v1").glob("*.jsonl"))
+    yt_script_draft_bus_files = sorted((storage_dir / "buses" / "news_yt_script_draft" / "v1").glob("*.jsonl"))
     drafts_dir = data_dir / "drafts" / digest_id
     quarantine_files = sorted((data_dir / "quarantine").glob(f"V*{digest_id}*.jsonl"))
 
+    latest_briefs = _latest_briefs(brief_files, digest_id)
+    digest_brief_ids = {str(row.get("brief_id") or "").strip() for row in latest_briefs if str(row.get("brief_id") or "").strip()}
+    bus_article_drafts, bus_yt_script_drafts = _latest_draft_bus_records(
+        article_draft_bus_files,
+        yt_script_draft_bus_files,
+        digest_brief_ids,
+    )
+    legacy_article_drafts: list[dict[str, Any]] = []
+    legacy_yt_script_drafts: list[dict[str, Any]] = []
+    need_legacy_article_drafts = not bus_article_drafts
+    need_legacy_yt_script_drafts = not bus_yt_script_drafts
+    if need_legacy_article_drafts or need_legacy_yt_script_drafts:
+        legacy_article_drafts, legacy_yt_script_drafts = _latest_draft_records(drafts_dir)
+
+    latest_article_drafts = bus_article_drafts or legacy_article_drafts
+    latest_yt_script_drafts = bus_yt_script_drafts or legacy_yt_script_drafts
+
+    contract_inputs = {
+        "piece_brief_bus": bool(latest_briefs),
+        "article_draft_bus": bool(bus_article_drafts),
+        "yt_script_draft_bus": bool(bus_yt_script_drafts),
+    }
+    fallback_inputs = {
+        "pf_out": bool(pf_files and not latest_briefs),
+        "data_drafts": bool((not bus_article_drafts and legacy_article_drafts) or (not bus_yt_script_drafts and legacy_yt_script_drafts)),
+        "quarantine": bool(quarantine_files),
+    }
+
     metrics = {
         "seed_ideas_emitted": _count_seed_ideas(pf_files),
-        "briefs_emitted": _count_briefs(brief_files, digest_id),
-        "drafts_emitted": _count_drafts(drafts_dir),
+        "briefs_emitted": len(latest_briefs),
+        "drafts_emitted": len(latest_article_drafts) + len(latest_yt_script_drafts),
         "fallback_legacy_count": 0,
         "schema_failures": 0,
     }
@@ -290,8 +393,6 @@ def build_editorial_index(storage_dir: Path, data_dir: Path, digest_at: str | No
     metrics["fallback_legacy_count"] = fallback_count
     metrics["schema_failures"] = schema_fails
 
-    latest_briefs = _latest_briefs(brief_files, digest_id)
-    latest_article_drafts, latest_yt_script_drafts = _latest_draft_records(drafts_dir)
     fallback_events = _fallback_summary(data_dir / "quarantine", digest_id)
     action_candidates = _build_action_candidates(latest_briefs, latest_article_drafts, latest_yt_script_drafts)
 
@@ -300,9 +401,13 @@ def build_editorial_index(storage_dir: Path, data_dir: Path, digest_at: str | No
         "built_at": built_at,
         "status": _status_for(metrics),
         "metrics": metrics,
+        "contract_inputs": contract_inputs,
+        "fallback_inputs": fallback_inputs,
         "pointers": {
             "pf_outputs": [str(p) for p in pf_files[-5:]],
             "brief_files": [str(p) for p in brief_files[-10:]],
+            "article_draft_bus_files": [str(p) for p in article_draft_bus_files[-10:]],
+            "yt_script_draft_bus_files": [str(p) for p in yt_script_draft_bus_files[-10:]],
             "draft_files": [str(p) for p in sorted(drafts_dir.glob("*.jsonl"))[-10:]] if drafts_dir.exists() else [],
             "quarantine_files": [str(p) for p in quarantine_files[-10:]],
         },

--- a/tests/test_build_editorial_access_indexes.py
+++ b/tests/test_build_editorial_access_indexes.py
@@ -88,6 +88,8 @@ def test_build_editorial_access_indexes_with_partial_data(tmp_path: Path):
     assert payload["metrics"]["drafts_emitted"] == 1
     assert payload["metrics"]["fallback_legacy_count"] == 1
     assert payload["metrics"]["schema_failures"] == 1
+    assert payload["contract_inputs"] == {"piece_brief_bus": True, "article_draft_bus": False, "yt_script_draft_bus": False}
+    assert payload["fallback_inputs"] == {"pf_out": False, "data_drafts": True, "quarantine": True}
     assert payload["status"] == "degraded"
     assert payload["human_handoff"]["status"] == "needs-attention"
     assert len(payload["human_handoff"]["latest_briefs"]) == 1
@@ -122,6 +124,8 @@ def test_build_editorial_access_indexes_no_data(tmp_path: Path):
     assert payload["status"] == "no-data"
     assert payload["metrics"]["seed_ideas_emitted"] == 0
     assert payload["human_handoff"]["status"] == "no-data"
+    assert payload["contract_inputs"] == {"piece_brief_bus": False, "article_draft_bus": False, "yt_script_draft_bus": False}
+    assert payload["fallback_inputs"] == {"pf_out": False, "data_drafts": False, "quarantine": False}
     assert payload["human_handoff"]["latest_briefs"] == []
 
 
@@ -168,3 +172,90 @@ def test_build_editorial_access_indexes_separates_yt_drafts(tmp_path: Path):
     assert len(payload["human_handoff"]["latest_yt_script_drafts"]) == 1
     assert payload["human_handoff"]["action_candidates"][0]["target_format"] == "yt_script"
     assert payload["human_handoff"]["action_candidates"][0]["ready_state"] == "draft-ready"
+
+
+def test_build_editorial_access_indexes_prefers_draft_buses_without_pf_or_data_drafts(tmp_path: Path):
+    data = tmp_path / "data"
+    storage = tmp_path / "storage"
+    digest = "20260316T02"
+
+    _write_jsonl(
+        storage / "buses" / "news_piece_brief" / "v1" / "npb_bus.jsonl",
+        [
+            {
+                "schema_name": "news_piece_brief.v1",
+                "digest_id_hour": digest,
+                "brief_id": "npb_bus",
+                "topic": "Economia",
+                "working_title": "Brief bus title",
+                "format_candidates": ["both"],
+            }
+        ],
+    )
+    _write_jsonl(
+        storage / "buses" / "news_article_draft" / "v1" / "article_npb_bus.jsonl",
+        [
+            {
+                "schema_name": "news_article_draft.v1",
+                "schema_status": "experimental_structured",
+                "draft_id": "article_npb_bus",
+                "brief_id": "npb_bus",
+                "title": "Article draft title",
+                "dek": "Article dek",
+                "lede": "Article lede",
+                "sections": [{"section_id": "sec_1", "heading": "Heading", "summary": "Summary"}],
+                "body_markdown": "# Article draft title",
+                "citations": [],
+                "fact_check_flags": [],
+                "revision_notes": [],
+            }
+        ],
+    )
+    _write_jsonl(
+        storage / "buses" / "news_yt_script_draft" / "v1" / "yt_npb_bus.jsonl",
+        [
+            {
+                "schema_name": "news_yt_script_draft.v1",
+                "schema_status": "experimental_structured",
+                "script_id": "yt_npb_bus",
+                "brief_id": "npb_bus",
+                "title": "YT draft title",
+                "thumbnail_hook": "Hook",
+                "cold_open": "Cold open",
+                "segment_outline": [{"segment_id": "seg_1", "heading": "Heading", "beat": "Beat", "estimated_seconds": 30}],
+                "full_script": "Full script",
+                "voice_notes": [],
+                "visual_notes": [],
+                "citations": [],
+            }
+        ],
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--storage-dir",
+            str(storage),
+            "--data-dir",
+            str(data),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    payload = json.loads((storage / "indexes" / "editorial_latest.json").read_text(encoding="utf-8"))
+    assert payload["digest_at"] == digest
+    assert payload["status"] == "ok"
+    assert payload["human_handoff"]["status"] == "ready"
+    assert payload["metrics"]["seed_ideas_emitted"] == 0
+    assert payload["metrics"]["briefs_emitted"] == 1
+    assert payload["metrics"]["drafts_emitted"] == 2
+    assert payload["contract_inputs"] == {"piece_brief_bus": True, "article_draft_bus": True, "yt_script_draft_bus": True}
+    assert payload["fallback_inputs"] == {"pf_out": False, "data_drafts": False, "quarantine": False}
+    assert payload["pointers"]["pf_outputs"] == []
+    assert payload["pointers"]["draft_files"] == []
+    assert len(payload["human_handoff"]["latest_article_drafts"]) == 1
+    assert len(payload["human_handoff"]["latest_yt_script_drafts"]) == 1
+    assert payload["human_handoff"]["action_candidates"][0]["target_format"] == "yt_script"

--- a/tests/test_news_editorial_briefs_pipeline.py
+++ b/tests/test_news_editorial_briefs_pipeline.py
@@ -68,3 +68,101 @@ def test_stage06_brief_id_is_stable_by_digest_group_and_idea() -> None:
 
     assert one == two
     assert one.startswith("npb_")
+
+
+def test_draft_bus_writer_promotes_stage05_draft_to_schema_valid_buses(tmp_path) -> None:
+    from apps.news_editorial.src.news_editorial.draft_bus_writer import (
+        article_draft_from_stage05,
+        validate_article_draft,
+        validate_yt_script_draft,
+        write_article_draft,
+        write_yt_script_draft,
+        yt_script_draft_from_stage05,
+    )
+
+    stage05_draft = {
+        "digest_id_hour": "20260101T01",
+        "index_id": "IDX001",
+        "topic": "Economía",
+        "headline": "Titular desde brief",
+        "dek": "Ángulo desde brief",
+        "citations": [{"url": "https://example.com/a", "title": "Fuente", "source": "Example"}],
+        "cluster_id": "npb_123",
+        "meta": {"brief_id": "npb_123"},
+    }
+
+    article = article_draft_from_stage05(stage05_draft)
+    yt_script = yt_script_draft_from_stage05(stage05_draft)
+
+    validate_article_draft(article)
+    validate_yt_script_draft(yt_script)
+    article_path = write_article_draft(article, bus_dir=tmp_path / "news_article_draft" / "v1")
+    yt_path = write_yt_script_draft(yt_script, bus_dir=tmp_path / "news_yt_script_draft" / "v1")
+
+    assert article_path.exists()
+    assert yt_path.exists()
+    assert article_path.read_text(encoding="utf-8").count("\n") == 1
+    assert yt_path.read_text(encoding="utf-8").count("\n") == 1
+
+
+def test_stage05_writes_draft_buses_before_optional_mirror(tmp_path, monkeypatch) -> None:
+    import importlib
+    import json
+
+    data_dir = tmp_path / "data"
+    storage_dir = tmp_path / "storage"
+    digest_id = "20260314T17"
+
+    monkeypatch.setenv("DATA_DIR", str(data_dir))
+    monkeypatch.setenv("STORAGE_DIR", str(storage_dir))
+    monkeypatch.setenv("DIGEST_AT", digest_id)
+    monkeypatch.setenv("DRY_RUN", "1")
+    monkeypatch.setenv("WRITE_DRAFT_MIRROR", "0")
+
+    digest_map = data_dir / "digest_map" / f"{digest_id}.csv"
+    digest_map.parent.mkdir(parents=True, exist_ok=True)
+    digest_map.write_text(
+        "digest_file,article_id,index_id,Title,Source,Link,Published,Topic\n"
+        "A_20260314T1700,1,IDX001,Título mapeado,Fuente,https://example.com/a,2026-03-14T17:10:00Z,Economía\n",
+        encoding="utf-8",
+    )
+    pf_out = data_dir / "pf_out" / f"pfout_{digest_id}.jsonl"
+    pf_out.parent.mkdir(parents=True, exist_ok=True)
+    pf_out.write_text(
+        json.dumps({"digest_group_id": f"{digest_id}::A::Economia::01", "seed_ideas": {"seed_ideas": []}}) + "\n",
+        encoding="utf-8",
+    )
+    brief_bus = storage_dir / "buses" / "news_piece_brief" / "v1" / "npb_123.jsonl"
+    brief_bus.parent.mkdir(parents=True, exist_ok=True)
+    brief_bus.write_text(
+        json.dumps(
+            {
+                "schema_name": "news_piece_brief.v1",
+                "brief_id": "npb_123",
+                "digest_id_hour": digest_id,
+                "digest_file": "A_20260314T1700",
+                "topic": "Economía",
+                "working_title": "Titular desde brief",
+                "angle": "Ángulo desde brief",
+                "source_index_ids": ["IDX001"],
+                "format_candidates": ["both"],
+            },
+            ensure_ascii=False,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    mod = importlib.reload(stage05)
+    monkeypatch.setattr(mod.db, "start_run", lambda *a, **k: None)
+    monkeypatch.setattr(mod.db, "finish_run", lambda *a, **k: None)
+
+    assert mod.run() == 0
+
+    article_files = list((storage_dir / "buses" / "news_article_draft" / "v1").glob("*.jsonl"))
+    yt_files = list((storage_dir / "buses" / "news_yt_script_draft" / "v1").glob("*.jsonl"))
+    assert len(article_files) == 1
+    assert len(yt_files) == 1
+    assert not (data_dir / "drafts" / digest_id).exists()
+    assert json.loads(article_files[0].read_text(encoding="utf-8"))["schema_name"] == "news_article_draft.v1"
+    assert json.loads(yt_files[0].read_text(encoding="utf-8"))["schema_name"] == "news_yt_script_draft.v1"


### PR DESCRIPTION
### Motivation

- Make draft buses (`news_article_draft.v1` / `news_yt_script_draft.v1`) the canonical Level 1 draft contract and keep `data/drafts/*` as an optional transitional mirror. 
- Ensure editorial handoff (`editorial_latest.json`) prefers schema-valid buses over raw PromptFlow runtime evidence. 
- Centralize an owner entrypoint that runs PromptFlow → briefs → drafts → editorial index, and document the editorial artifact ladder and fallback policy. 

### Description

- Add `apps/news_editorial/src/news_editorial/draft_bus_writer.py` which validates records against JSON Schema, composes bus records from stage05 mirrors, and atomically writes `news_article_draft.v1` and `news_yt_script_draft.v1` files. 
- Update `stage05_explode_pf_outputs.py` to write validated draft bus rows before optionally mirroring to `data/drafts/*`, use `WRITE_DRAFT_MIRROR` to disable mirror writes, and enqueue using the bus path when mirror is disabled; fallback behavior is controlled by `LEGACY_EDITORIAL_FALLBACK`. 
- Clarify `stage04_promptflow_run.py` semantics to treat `data/digest_jsonls/*` as the Level 0 input seam and `data/pf_out/*` as runtime evidence. 
- Enhance `scripts/build_editorial_access_indexes.py` to resolve digest ids from brief buses, prefer draft buses when present (fall back to `data/drafts/*` otherwise), and emit `contract_inputs`/`fallback_inputs` plus bus pointers in the index payload. 
- Add and adjust docs and operator tooling: expand `apps/news_editorial/README.md` and `runbook.md` with the artifact ladder and component ownership, update `entrypoints/run_editorial_owner.sh` to optionally run the index builder (`RUN_EXPORTS`) and improve logs, and add small Makefile/help text edits. 
- Add unit tests for bus-based index building and draft bus writer behavior and update existing index tests to assert new fields. 

### Testing

- Ran the updated test modules `tests/test_build_editorial_access_indexes.py` and `tests/test_news_editorial_briefs_pipeline.py` via `pytest` and observed all assertions in these tests succeed. 
- Exercised the stage05 flow under `WRITE_DRAFT_MIRROR=0` in tests to verify bus writes occur and the mirror is not created, and these checks passed. 
- Verified index builder scenarios for (no-data, partial legacy fallback, and bus-backed drafts) via the new/updated tests; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00be408500832d8ccfe848d366507d)