### PR TITLE
Add editorial handoff packet materializer, Makefile target, runbook docs, and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ define _env_prefix
 DIGEST_AT=$(DIGEST_AT) DRY_RUN=$(DRY_RUN) LIMIT=$(LIMIT) SAMPLE=$(SAMPLE) NULL_SINK=$(NULL_SINK)
 endef
 
-.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 s06 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a build-news-access-indexes build-editorial-access-indexes build-enrich-access-indexes validate-publish-surface publish-last-mile-snapshot heartbeat-start heartbeat-stop heartbeat-status
+.PHONY: help hour env preflight-runtime s01 s02 s03 s04 s05 s06 prep pf explode all stage-any scrape-one requeue-fails ls pf-ls clean-null export-pr3a build-news-access-indexes build-editorial-access-indexes materialize-editorial-handoff build-enrich-access-indexes validate-publish-surface publish-last-mile-snapshot heartbeat-start heartbeat-stop heartbeat-status
 
 help:      ## Show help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## ' Makefile | sed 's/:.*## / — /' | sort
@@ -150,6 +150,9 @@ build-news-access-indexes: ## Build compact readable latest-news access indexes 
 
 build-editorial-access-indexes: ## Build compact editorial status index (seed/brief/draft/fallback)
 	@$(PYTHON) scripts/build_editorial_access_indexes.py --digest-at $(DIGEST_AT)
+
+materialize-editorial-handoff: ## Materialize editorial handoff packet from latest editorial index
+	@$(PYTHON) -m apps.news_editorial.src.news_editorial.handoff_packet --index storage/indexes/editorial_latest.json --out artifacts/editorial_handoff/latest
 
 build-enrich-access-indexes: ## Build compact enrich status index from scraped_article.v1 bus
 	@$(PYTHON) scripts/build_enrich_access_indexes.py

--- a/apps/news_editorial/runbook.md
+++ b/apps/news_editorial/runbook.md
@@ -191,3 +191,23 @@ Expected ED3 behavior:
 - No refactor of PromptFlow internals.
 - No schema definition changes.
 - No file moves/deletes in legacy.
+
+## Editorial handoff packet
+
+Command:
+
+```bash
+make materialize-editorial-handoff
+```
+
+Output:
+
+- `artifacts/editorial_handoff/latest/README.md`
+- `artifacts/editorial_handoff/latest/publication_candidates.md`
+- `artifacts/editorial_handoff/latest/fallback_status.md`
+- `artifacts/editorial_handoff/latest/editorial_latest.copy.json`
+- `artifacts/editorial_handoff/latest/provenance.json`
+
+Purpose:
+
+- Materialize a small human-readable handoff packet from `storage/indexes/editorial_latest.json` for editorial triage and agent handoff without reading Level 0 runtime output folders directly.

--- a/apps/news_editorial/src/news_editorial/handoff_packet.py
+++ b/apps/news_editorial/src/news_editorial/handoff_packet.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _read_index(index_path: Path) -> dict[str, Any]:
+    if not index_path.exists():
+        return {}
+    try:
+        payload = json.loads(index_path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.write_text(content.rstrip() + "\n", encoding="utf-8")
+
+
+def _collect_candidates(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    handoff = payload.get("human_handoff")
+    if not isinstance(handoff, dict):
+        return []
+    action_candidates = handoff.get("action_candidates")
+    if not isinstance(action_candidates, list):
+        return []
+    return [c for c in action_candidates if isinstance(c, dict)]
+
+
+def _readme_content(index_path: Path, packet_dir: Path, payload: dict[str, Any], candidate_count: int) -> str:
+    digest_at = payload.get("digest_at")
+    status = payload.get("status")
+    built_at = payload.get("built_at")
+    return f"""# Editorial Handoff Packet
+
+This packet is a human-readable handoff surface materialized from the Level 2 editorial index.
+
+- **Input index:** `{index_path}`
+- **Packet directory:** `{packet_dir}`
+- **Index digest:** `{digest_at or 'unknown'}`
+- **Index status:** `{status or 'no-data'}`
+- **Index built_at:** `{built_at or 'unknown'}`
+- **Candidate count:** `{candidate_count}`
+
+## Command
+
+```bash
+python -m apps.news_editorial.src.news_editorial.handoff_packet \
+  --index storage/indexes/editorial_latest.json \
+  --out artifacts/editorial_handoff/latest
+```
+
+## What this packet proves
+
+- The handoff can be consumed without reading raw PromptFlow output or draft mirrors.
+- Contract/fallback posture is explicit from the index.
+- Publication candidates (if any) are listed for editorial triage.
+
+## Human next step
+
+1. Review `publication_candidates.md`.
+2. Review `fallback_status.md` for degradation/fallback context.
+3. Review `source_pointers.json` for artifact trace links.
+4. Publish or request revisions based on ready state and target format.
+"""
+
+
+def _publication_candidates_content(candidates: list[dict[str, Any]]) -> str:
+    lines = ["# Publication Candidates", ""]
+    if not candidates:
+        lines.append("No candidates available in the current editorial index.")
+        return "\n".join(lines)
+
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for c in candidates:
+        grouped[str(c.get("target_format") or "unknown")].append(c)
+
+    for target_format in sorted(grouped.keys()):
+        lines.extend([
+            f"## Format: `{target_format}`",
+            "",
+            "| title | topic | ready state | source | brief id | draft path | candidate id |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ])
+
+        for i, c in enumerate(grouped[target_format], start=1):
+            title = str(c.get("title") or "")
+            topic = str(c.get("topic") or "")
+            ready_state = str(c.get("ready_state") or "")
+            source = str(c.get("source") or "")
+            brief_id = str(c.get("brief_id") or "")
+            draft_path = str(c.get("path") or c.get("draft_path") or "")
+            candidate_id = str(c.get("candidate_id") or c.get("id") or f"{target_format}_{i}")
+            lines.append(f"| {title} | {topic} | {ready_state} | {source} | {brief_id} | {draft_path} | {candidate_id} |")
+
+        lines.append("")
+
+    return "\n".join(lines).rstrip()
+
+
+def _fallback_status_content(payload: dict[str, Any]) -> str:
+    contract_inputs = payload.get("contract_inputs") if isinstance(payload.get("contract_inputs"), dict) else {}
+    fallback_inputs = payload.get("fallback_inputs") if isinstance(payload.get("fallback_inputs"), dict) else {}
+    status = str(payload.get("status") or "no-data")
+
+    bus_first = bool(any(bool(v) for v in contract_inputs.values()))
+    pf_needed = bool(fallback_inputs.get("pf_out"))
+    drafts_needed = bool(fallback_inputs.get("data_drafts"))
+
+    lines = [
+        "# Fallback Status",
+        "",
+        f"- index status: `{status}`",
+        f"- bus-first handoff: `{'yes' if bus_first else 'no'}`",
+        f"- used PF output fallback: `{'yes' if pf_needed else 'no'}`",
+        f"- used legacy drafts fallback: `{'yes' if drafts_needed else 'no'}`",
+        "",
+        "## contract_inputs",
+        "```json",
+        json.dumps(contract_inputs, ensure_ascii=False, indent=2),
+        "```",
+        "",
+        "## fallback_inputs",
+        "```json",
+        json.dumps(fallback_inputs, ensure_ascii=False, indent=2),
+        "```",
+    ]
+    if status in {"degraded", "no-data"}:
+        lines.extend([
+            "",
+            "## notes",
+            "- Handoff is degraded or empty; verify upstream editorial run health before publication decisions.",
+        ])
+
+    return "\n".join(lines)
+
+
+def _source_pointers_payload(payload: dict[str, Any], index_path: Path, out_dir: Path) -> dict[str, Any]:
+    pointers = payload.get("pointers") if isinstance(payload.get("pointers"), dict) else {}
+    return {
+        "source_index": str(index_path),
+        "packet_dir": str(out_dir),
+        "pointers": pointers,
+    }
+
+
+def materialize_handoff_packet(index_path: Path, out_dir: Path) -> Path:
+    payload = _read_index(index_path)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    candidates = _collect_candidates(payload)
+    contract_inputs = payload.get("contract_inputs") if isinstance(payload.get("contract_inputs"), dict) else {}
+    fallback_inputs = payload.get("fallback_inputs") if isinstance(payload.get("fallback_inputs"), dict) else {}
+
+    _write_text(out_dir / "README.md", _readme_content(index_path, out_dir, payload, len(candidates)))
+    _write_text(out_dir / "publication_candidates.md", _publication_candidates_content(candidates))
+    _write_text(out_dir / "fallback_status.md", _fallback_status_content(payload))
+    _write_json(out_dir / "editorial_latest.copy.json", payload)
+    _write_json(out_dir / "source_pointers.json", _source_pointers_payload(payload, index_path, out_dir))
+
+    provenance = {
+        "built_at": _utc_now_iso(),
+        "source_index": str(index_path),
+        "packet_dir": str(out_dir),
+        "contract_inputs": contract_inputs,
+        "fallback_inputs": fallback_inputs,
+        "candidate_count": len(candidates),
+    }
+    _write_json(out_dir / "provenance.json", provenance)
+    return out_dir
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Materialize editorial handoff packet from editorial_latest index")
+    p.add_argument("--index", default="storage/indexes/editorial_latest.json")
+    p.add_argument("--out", default="artifacts/editorial_handoff/latest")
+    return p.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    out_dir = materialize_handoff_packet(Path(args.index), Path(args.out))
+    print(f"[handoff-packet] out={out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_editorial_handoff_packet.py
+++ b/tests/test_editorial_handoff_packet.py
@@ -1,0 +1,78 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+MODULE = "apps.news_editorial.src.news_editorial.handoff_packet"
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _run(index_path: Path, out_dir: Path) -> None:
+    subprocess.run(
+        [sys.executable, "-m", MODULE, "--index", str(index_path), "--out", str(out_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_materialize_editorial_handoff_packet_writes_required_files(tmp_path: Path):
+    index_path = tmp_path / "storage" / "indexes" / "editorial_latest.json"
+    out_dir = tmp_path / "artifacts" / "editorial_handoff" / "latest"
+
+    _write_json(
+        index_path,
+        {
+            "digest_at": "20260523T11",
+            "status": "ok",
+            "contract_inputs": {"piece_brief_bus": True, "article_draft_bus": True, "yt_script_draft_bus": False},
+            "fallback_inputs": {"pf_out": False, "data_drafts": False, "quarantine": False},
+            "pointers": {"brief_files": ["storage/buses/news_piece_brief/v1/npb_1.jsonl"]},
+            "human_handoff": {
+                "action_candidates": [
+                    {
+                        "title": "Candidate title",
+                        "topic": "Economy",
+                        "target_format": "article",
+                        "ready_state": "draft-ready",
+                        "source": "draft",
+                        "path": "storage/buses/news_article_draft/v1/article_1.jsonl",
+                    }
+                ]
+            },
+        },
+    )
+
+    _run(index_path, out_dir)
+
+    assert (out_dir / "README.md").exists()
+    assert (out_dir / "publication_candidates.md").exists()
+    assert (out_dir / "fallback_status.md").exists()
+    assert (out_dir / "editorial_latest.copy.json").exists()
+    assert (out_dir / "provenance.json").exists()
+
+    provenance = json.loads((out_dir / "provenance.json").read_text(encoding="utf-8"))
+    assert "candidate_count" in provenance
+    assert provenance["candidate_count"] == 1
+
+
+def test_materialize_editorial_handoff_packet_no_data_input(tmp_path: Path):
+    index_path = tmp_path / "storage" / "indexes" / "editorial_latest.json"
+    out_dir = tmp_path / "artifacts" / "editorial_handoff" / "latest"
+    _write_json(index_path, {})
+
+    _run(index_path, out_dir)
+
+    publication_md = (out_dir / "publication_candidates.md").read_text(encoding="utf-8")
+    assert "No candidates available" in publication_md
+
+    provenance = json.loads((out_dir / "provenance.json").read_text(encoding="utf-8"))
+    assert provenance["candidate_count"] == 0
+
+    source_pointers = json.loads((out_dir / "source_pointers.json").read_text(encoding="utf-8"))
+    assert source_pointers["pointers"] == {}


### PR DESCRIPTION
### Motivation

- Provide a small human-readable editorial handoff packet derived from the Level 2 `editorial_latest.json` index to simplify editorial triage without inspecting raw PromptFlow outputs.  
- Capture publication candidates, fallback status, source pointers, and provenance to make publication decisions and debugging easier.  
- Expose the feature via the build system so operators can materialize the packet with a single `make` command.

### Description

- Add `apps/news_editorial/src/news_editorial/handoff_packet.py` which implements `materialize_handoff_packet` and a CLI for materializing a packet containing `README.md`, `publication_candidates.md`, `fallback_status.md`, `editorial_latest.copy.json`, `source_pointers.json`, and `provenance.json`.  
- Add `materialize-editorial-handoff` Makefile target and include it in `.PHONY` so the packet can be produced with `make materialize-editorial-handoff` using the project Python.  
- Update `apps/news_editorial/runbook.md` with a new `Editorial handoff packet` section documenting the `make` command and expected outputs.  
- Add unit tests in `tests/test_editorial_handoff_packet.py` that exercise the CLI end-to-end and assert required files and expected payload fields are written.

### Testing

- Ran the new unit tests `tests/test_editorial_handoff_packet.py` with `pytest` which execute the CLI against temporary indices and assert the packet files and provenance counts are produced and correct; the tests passed.  
- Basic invocation via `python -m apps.news_editorial.src.news_editorial.handoff_packet --index <index> --out <out>` was exercised by the tests and printed the output path on success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11a50b3038832db43115a8fd19bfa7)